### PR TITLE
Show a short commit hash instead of date

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       if: "!startsWith(github.ref, 'refs/tags/v')"
       run: |
         echo "BUILD_TIMESTAMP=$(date -u '+%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV
-        echo "VERSION=$(date -u '+%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV
+        echo "VERSION=ref:$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
     - name: Set version for tagged builds
       if: startsWith(github.ref, 'refs/tags/v')

--- a/MCA/Makefile
+++ b/MCA/Makefile
@@ -80,10 +80,12 @@ EE_OBJS += ../PS2/ioprp_$(MGMODE).o
 	bin2c $< $@ ioprp
 endif
 
-ifdef VERSION
+ifndef VERSION
+VERSION := $(shell (hash=$$(git rev-parse --short HEAD 2>/dev/null) && echo "ref:$$hash" || date "+%Y-%m-%d_%H-%M-%S"))
+endif
+
 #quotes just in case there are spaces there
 EE_CFLAGS += -DVERSION="\"$(VERSION)\""
-endif
 
 clean:
 	echo "Cleaning..."

--- a/MCA/Version.h
+++ b/MCA/Version.h
@@ -1,4 +1,5 @@
 #ifndef _VERSION_H_
+#define _VERSION_H_
 
 #ifndef VERSION
 


### PR DESCRIPTION
For non versioned builds, display a short commit hash instead of date. Use a timestamp if it fails (e.g. not git repository).