### PR TITLE
Automatically select a language file based on the OSD settings.

### DIFF
--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -114,25 +114,25 @@ int CPS2Application::main(int argc, char *argv[])
 
 void CPS2Application::initLanguage()
 {
-	std::string langfile = CResources::boot_path + "lang.lng";
-	if (!loadLanguage(langfile))
+	
+	static const char* languageFiles[] = {
+		"lang.lng",	// Japanese does not have a valid font yet
+		"lang_en.lng",
+		"lang_fr.lng",
+		"lang_es.lng",
+		"lang_de.lng",
+		"lang_it.lng",
+		"lang_du.lng",
+		"lang_pt.lng",
+		"lang_ru.lng", // Russian and further languages require XEB+ 2024 or newer in order to be detected. Else, they will default to English.
+		// Korean, Traditional and Simplified Chinese do not have a valid font yet
+	};
+	
+	std::string defaultLangFile = CResources::boot_path + "lang.lng";
+	if (!loadLanguage(defaultLangFile))
 	{
 		int systemLanguage = configGetLanguage();
-		static const char* languageFiles[] = {
-			"lang.lng",   // Japanese has no support in the font
-			"lang_en.lng",
-			"lang_fr.lng",
-			"lang_es.lng",
-			"lang_de.lng",
-			"lang_it.lng",
-			"lang_du.lng",
-			"lang_pt.lng",
-			"lang_ru.lng", // Requires XEB+ 2024 onwards to be detected, else, it will default to 1 (English)
-			"lang.lng",   // Korean has no support in the font
-			"lang.lng",	// Chinese has no support in the font
-			"lang.lng"	// Chinese has no support in the font
-		};
-		if (systemLanguage >= 1 && systemLanguage <= 8)
+		if (systemLanguage >= 0 && systemLanguage < sizeof(languageFiles) / sizeof(languageFiles[0]))
 		{
 			std::string langfile = CResources::boot_path + languageFiles[systemLanguage];
 			loadLanguage(langfile);

--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -1,3 +1,4 @@
+#include <osd_config.h>
 #include "PS2Application.h"
 #include "../Include/GUIFrameTimerPS2.h"
 #include "../Include/GUIFrameRendererPS2.h"
@@ -48,9 +49,7 @@ int CPS2Application::main(int argc, char *argv[])
 	
 	setBootPath(argv[0]);
 	printf("BOOT path: %s\n", CResources::boot_path.c_str());
-
-	std::string langfile = CResources::boot_path + "lang.lng";
-	loadLanguage(langfile);
+	initLanguage();
 
 	ResetEE(0xffffffff);
 	CGUIFramePS2Modules::initPS2Iop(CResources::iopreset, true);
@@ -111,6 +110,34 @@ int CPS2Application::main(int argc, char *argv[])
 	ps2renderer.deinitRenderer();
 	ps2Timer.deinitTimer();
 	return 0;
+}
+
+void CPS2Application::initLanguage()
+{
+	std::string langfile = CResources::boot_path + "lang.lng";
+	if (!loadLanguage(langfile))
+	{
+		int systemLanguage = configGetLanguage();
+		static const char* languageFiles[] = {
+			"lang.lng",   // Japanese has no support in the font
+			"lang_en.lng",
+			"lang_fr.lng",
+			"lang_es.lng",
+			"lang_de.lng",
+			"lang_it.lng",
+			"lang_du.lng",
+			"lang_pt.lng",
+			"lang_ru.lng", // Requires XEB+ 2024 onwards to be detected, else, it will default to 1 (English)
+			"lang.lng",   // Korean has no support in the font
+			"lang.lng",	// Chinese has no support in the font
+			"lang.lng"	// Chinese has no support in the font
+		};
+		if (systemLanguage >= 1 && systemLanguage <= 8)
+		{
+			std::string langfile = CResources::boot_path + languageFiles[systemLanguage];
+			loadLanguage(langfile);
+		}
+	}
 }
 
 bool CPS2Application::loadLanguage(const std::string& langfile)

--- a/MCA/PS2/PS2Application.h
+++ b/MCA/PS2/PS2Application.h
@@ -10,6 +10,7 @@ private:
 	static CPS2Application *m_pInstance;
 	CPS2Application(void);
 	static bool loadLanguage(const std::string& langfile);
+	static void initLanguage();
 	static void setBootPath(const char* path);
 public:
 	~CPS2Application(void);


### PR DESCRIPTION
- By default, the app looks for lang.lng and loads it. You can use that file to force a language or use one not supported by the OSD settings.
- These languages will be loaded automatically depending on the OSD settings if lang.lng is not present: lang_en.lng, lang_fr.lng, lang_es.lng, lang_de.lng, lang_it.lng, lang_du.lng, lang_pt.lng.
- Also, lang_ru.lng is supported if the user runs MCA from XEB+ 2024 onwards.
- If no language file is found, it will use the embed English language.