### PR TITLE
Simplify IOP reset

### DIFF
--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -53,7 +53,7 @@ int CPS2Application::main(int argc, char *argv[])
 	bool languageLoaded = initLanguage(CResources::boot_path); //allow to load before iopreset (potentially unsupported devices with already loaded modules)
 
 	ResetEE(0xffffffff);
-	CGUIFramePS2Modules::initPS2Iop(CResources::iopreset, true);
+	CGUIFramePS2Modules::initPS2Iop(CResources::iopreset);
 	CGUIFramePS2Modules::loadMcModules();
 	CGUIFramePS2Modules::loadUsbModules();
 	CGUIFramePS2Modules::loadCdvdModules();

--- a/PS2/GUIFramePS2Modules.cpp
+++ b/PS2/GUIFramePS2Modules.cpp
@@ -44,27 +44,15 @@ void CGUIFramePS2Modules::iopReset(bool xmodules)
 {
 #ifdef MGMODE
 	while(!SifIopRebootBuffer(ioprp, size_ioprp));
+#elif defined(USE_HOMEBREW_MODULES)
+	while (!SifIopReset("", 0));
 #else
 	while(!SifIopReset("rom0:UDNL rom0:EELOADCNF",0));
 #endif
 	while(!SifIopSync());
 
-	fioExit();
-	SifExitIopHeap();
-	SifLoadFileExit();
-	SifExitRpc();
-	SifExitCmd();
 	SifInitRpc(0);
-	FlushCache(0);
-	FlushCache(2);
-	resetFlags();
-	m_use_xmodules = xmodules;
-
-	sbv_patch_enable_lmb();
-	sbv_patch_disable_prefix_check();
-	int ret, id;
-	id = SifExecModuleBuffer(iomanx_irx, size_iomanx_irx, 0, NULL, &ret);
-	IRX_REPORT("iomanX", id, ret);
+	finalizeIopState(xmodules);
 }
 bool CGUIFramePS2Modules::resetFlags()
 {
@@ -90,97 +78,25 @@ bool CGUIFramePS2Modules::resetFlags()
 
 void CGUIFramePS2Modules::initPS2Iop(bool reset, bool xmodules)
 {
-	int id, ret;
-	m_use_xmodules = xmodules;
-	m_modules_padman = false;
-	m_modules_sio2man = false;
-	m_modules_mcman = false;
-	m_modules_mcserv = false;
-	m_modules_poweroff = false;
-	m_modules_filexio = false;
-	m_modules_dev9 = false;
-	m_modules_fs = false;
-	m_modules_hdd = false;
-	m_modules_atad = false;
-	m_modules_usbd = false;
-	m_modules_usbhdfsd = false;
-	m_modules_cdvd = false;
-	m_modules_cdvd_init = false;
-	m_modules_fakehost = false;
-
 	SifInitRpc(0);
 	if (reset)
 	{
-		if (xmodules)
-		{
-			#ifdef MGMODE
-				while(!SifIopRebootBuffer(ioprp, size_ioprp));
-			#else
-				while(!SifIopReset("rom0:UDNL rom0:EELOADCNF",0));
-			#endif
-				while(!SifIopSync());
-			fioExit();
-			SifExitIopHeap();
-			SifLoadFileExit();
-			SifExitRpc();
-			SifExitCmd();
-			SifInitRpc(0);
-			FlushCache(0);
-			FlushCache(2);
-#ifdef USE_HOMEBREW_MODULES
-			id = SifExecModuleBuffer(sio2man_irx, size_sio2man_irx, 0, NULL, &ret);
-			IRX_REPORT("sio2man", id, ret);
-			id = SifExecModuleBuffer(mcman_irx, size_mcman_irx, 0, NULL, &ret);
-			IRX_REPORT("mcman", id, ret);
-			id = SifExecModuleBuffer(mcserv_irx, size_mcserv_irx, 0, NULL, &ret);
-			IRX_REPORT("mcserv", id, ret);
-			id = SifExecModuleBuffer(padman_irx, size_padman_irx, 0, NULL, &ret);
-			IRX_REPORT("padman", id, ret);
-#else
-			id = SifLoadStartModule("rom0:XSIO2MAN", 0, NULL, &ret);
-			IRX_REPORT("rom0:XSIO2MAN", id, ret);
-			id = SifLoadStartModule("rom0:XMCMAN", 0, NULL, &ret);
-			IRX_REPORT("rom0:XMCMAN", id, ret);
-			id = SifLoadStartModule("rom0:XMCSERV", 0, NULL, &ret);
-			IRX_REPORT("rom0:XMCSERV", id, ret);
-			id = SifLoadStartModule("rom0:XPADMAN", 0, NULL, &ret);
-			IRX_REPORT("rom0:XPADMAN", id, ret);
-#endif
-		}
-		#ifdef MGMODE
-			while(!SifIopRebootBuffer(ioprp, size_ioprp));
-		#else
-			while(!SifIopReset("rom0:UDNL rom0:EELOADCNF",0));
-		#endif
-			while(!SifIopSync());
+		iopReset(xmodules);
 	}
-	fioExit();
-	SifExitIopHeap();
-	SifLoadFileExit();
-	SifExitRpc();
-	SifExitCmd();
-	SifInitRpc(0);
-	FlushCache(0);
-	FlushCache(2);
+	else
+	{
+		finalizeIopState(xmodules);
+	}
+}
 
-	m_modules_padman = false;
-	m_modules_sio2man = false;
-	m_modules_mcman = false;
-	m_modules_mcserv = false;
-	m_modules_poweroff = false;
-	m_modules_filexio = false;
-	m_modules_dev9 = false;
-	m_modules_fs = false;
-	m_modules_hdd = false;
-	m_modules_atad = false;
-	m_modules_usbd = false;
-	m_modules_usbhdfsd = false;
-	m_modules_cdvd = false;
-	m_modules_cdvd_init = false;
-	m_modules_fakehost = false;
+void CGUIFramePS2Modules::finalizeIopState(bool xmodules)
+{
+	resetFlags();
+	m_use_xmodules = xmodules;
 
 	sbv_patch_enable_lmb();
 	sbv_patch_disable_prefix_check();
+	int id, ret;
 	id = SifExecModuleBuffer(iomanx_irx, size_iomanx_irx, 0, NULL, &ret);
 	IRX_REPORT("iomanX", id, ret);
 }

--- a/PS2/Include/GUIFramePS2Modules.h
+++ b/PS2/Include/GUIFramePS2Modules.h
@@ -65,7 +65,8 @@ public:
 	static bool loadHddModules();
 	static bool loadCdvdModules();
 	static bool loadFakehost(const char *path);
-	static void initPS2Iop(bool reset, bool xmodules);
+	static void initPS2Iop(bool reset, bool xmodules = true);
+	static void finalizeIopState(bool xmodules = true);
 	static void poweroffHandler(int i);
 	static void umountAll();
 };


### PR DESCRIPTION
Streamlines IOP reset a lot, by getting rid of workarounds that are apparently no longer needed.

Double reset with intermediate module loading was used to prevent issues with changes between XMODULES and standard modules. I can't replicate the issues on v1.0 PS2SDK.

Also extracted some common, duplicated code into a separate method.

Tested on an actual SCPH-50004 and in emulator.