### PR TITLE
Load language file after IOP reset

### DIFF
--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -50,7 +50,7 @@ int CPS2Application::main(int argc, char *argv[])
 	
 	setBootPath(argv[0]);
 	printf("BOOT path: %s\n", CResources::boot_path.c_str());
-	initLanguage();
+	initLanguage(CResources::boot_path);
 
 	ResetEE(0xffffffff);
 	CGUIFramePS2Modules::initPS2Iop(CResources::iopreset, true);
@@ -113,7 +113,7 @@ int CPS2Application::main(int argc, char *argv[])
 	return 0;
 }
 
-void CPS2Application::initLanguage()
+bool CPS2Application::initLanguage(const std::string& bootPath)
 {
 	
 	static const char* languageFiles[] = {
@@ -129,16 +129,16 @@ void CPS2Application::initLanguage()
 		// Korean, Traditional and Simplified Chinese do not have a valid font yet
 	};
 	
-	std::string defaultLangFile = CResources::boot_path + "lang.lng";
-	if (!loadLanguage(defaultLangFile))
-	{
-		int systemLanguage = configGetLanguage();
-		if (systemLanguage >= 0 && systemLanguage < static_cast<int>(countof(languageFiles)))
-		{
-			std::string systemLanguageFile = CResources::boot_path + languageFiles[systemLanguage];
-			loadLanguage(systemLanguageFile);
-		}
-	}
+	std::string defaultLangFile = bootPath + "lang.lng";
+	if (loadLanguage(defaultLangFile))
+		return true;
+
+	int systemLanguage = configGetLanguage();
+	if (systemLanguage < 0 || systemLanguage >= static_cast<int>(countof(languageFiles)))
+		return false;
+
+	std::string systemLanguageFile = bootPath + languageFiles[systemLanguage];
+	return loadLanguage(systemLanguageFile);
 }
 
 bool CPS2Application::loadLanguage(const std::string& langfile)

--- a/MCA/PS2/PS2Application.h
+++ b/MCA/PS2/PS2Application.h
@@ -10,7 +10,7 @@ private:
 	static CPS2Application *m_pInstance;
 	CPS2Application(void);
 	static bool loadLanguage(const std::string& langfile);
-	static void initLanguage();
+	static bool initLanguage(const std::string& langfile);
 	static void setBootPath(const char* path);
 public:
 	~CPS2Application(void);

--- a/MCA/PS2/PS2Application.h
+++ b/MCA/PS2/PS2Application.h
@@ -11,8 +11,11 @@ private:
 	CPS2Application(void);
 	static bool loadLanguage(const std::string& langfile);
 	static bool initLanguage(const std::string& bootPath);
-	std::string processHddBootPath(const std::string& bootPath);
+	static std::string processHddBootPath(const std::string& bootPath);
+	static std::string processMassBootPath(const std::string& bootPath);
+	static std::string processBootPath(const std::string& bootPath);
 	static void setBootPath(const char* path);
+	static bool waitForDisk(const std::string path, int delay);
 public:
 	~CPS2Application(void);
 	int main(int argc, char *argv[]);

--- a/MCA/PS2/PS2Application.h
+++ b/MCA/PS2/PS2Application.h
@@ -10,7 +10,8 @@ private:
 	static CPS2Application *m_pInstance;
 	CPS2Application(void);
 	static bool loadLanguage(const std::string& langfile);
-	static bool initLanguage(const std::string& langfile);
+	static bool initLanguage(const std::string& bootPath);
+	std::string processHddBootPath(const std::string& bootPath);
 	static void setBootPath(const char* path);
 public:
 	~CPS2Application(void);

--- a/PS2/GUIFramePS2Modules.cpp
+++ b/PS2/GUIFramePS2Modules.cpp
@@ -211,6 +211,17 @@ bool CGUIFramePS2Modules::loadSio2Man()
 #endif
 	return true;
 }
+bool CGUIFramePS2Modules::loadFileXio()
+{
+	if (!m_modules_filexio)
+	{
+		int id, ret;
+		id = SifExecModuleBuffer(&filexio_irx, size_filexio_irx, 0, NULL, &ret);
+		IRX_REPORT("fileXio", id, ret);
+		m_modules_filexio = true;
+	}
+	return true;
+}
 bool CGUIFramePS2Modules::loadPadModules()
 {
 	int id, ret;
@@ -293,7 +304,7 @@ bool CGUIFramePS2Modules::loadFakehost(const char *path)
 	{
 		int id, ret;
 		id = SifExecModuleBuffer(fakehost_irx, size_fakehost_irx, strlen(path), path, &ret);
-		IRX_REPORT("iomanX", id, ret);
+		IRX_REPORT("fakehost", id, ret);
 		m_modules_fakehost = true;
 	}
 	return true;
@@ -333,6 +344,7 @@ bool CGUIFramePS2Modules::loadUsbModules()
 		m_modules_usbhdfsd = true;
 	}
 #endif
+	loadFileXio();
 	return true;
 }
 
@@ -409,12 +421,7 @@ bool CGUIFramePS2Modules::loadHddModules()
 		poweroffSetCallback((poweroff_callback)poweroffHandler, NULL);
 		m_modules_poweroff = true;
 	}
-	if (!m_modules_filexio)
-	{
-		id = SifExecModuleBuffer(&filexio_irx, size_filexio_irx, 0, NULL, &ret);
-		IRX_REPORT("fileXio", id, ret);
-		m_modules_filexio = true;
-	}
+	loadFileXio();
 	if (!m_modules_dev9)
 	{
 		id = SifExecModuleBuffer(&ps2dev9_irx, size_ps2dev9_irx, 0, NULL, &ret);

--- a/PS2/Include/GUIFramePS2Modules.h
+++ b/PS2/Include/GUIFramePS2Modules.h
@@ -58,6 +58,7 @@ public:
 	static void iopReset(bool xmodules = false);
 	static bool resetFlags();
 	static bool loadSio2Man();
+	static bool loadFileXio();
 	static bool loadPadModules();
 	static bool loadMcModules();
 	static bool loadUsbModules();


### PR DESCRIPTION
Added support to load language files after IOP reset and module loading again (for cases when IOP is reset before launching the application and no device modules are loaded).

It will also recognize hdd boot path (`hdd0:partition:pfs:/path` format) and try to mount the partition.

For cases when multiple mass devices are being connected, it is possible for a mass device to change its number after reset and usb module loading (due to response times). It will try to detect it and use the proper device. The 50 retries are eyeballed based on tests and delays used in other applications. Seems to work with a few usb devices I tested it with. Might need some more testing in the future. The second delay is 1, because at this point we must've already waited maximum number of retries.

Also extracts loadFileXio into a separate method, as these are now needed for both hdd and mass.

Closes #39 