### PR TITLE
Fix a bug that caused the app being unable to unmount/remount a hdd partition

### DIFF
--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -233,6 +233,7 @@ bool CPS2Application::loadLanguage(const std::string& langfile)
 
 			CResources::mainLang.initLang(buff);
 			delete [] buff;
+			fioClose(fd);
 			return true;
 		}
 		fioClose(fd);


### PR DESCRIPTION
If a language file was read from hdd, it would prevent unmounting/remounting of a partition. And old bug with an opened file handle.