### PR TITLE
Extract fade in/out to a base class

### DIFF
--- a/GUIFramework/Include/IGUIFrameWindow.h
+++ b/GUIFramework/Include/IGUIFrameWindow.h
@@ -12,10 +12,9 @@ class CIGUIFrameWindow
 {
 protected:
 	std::vector<CIGUIFrameControl*> m_control_list;
-public:
 	CIGUIFrameWindow(void);
+public:
 	virtual ~CIGUIFrameWindow(void);
-	virtual int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false) = 0;
 };
 
 #endif //_IGUIFRAMEWINDOW_H_

--- a/MCA/GUIMcaAbout.cpp
+++ b/MCA/GUIMcaAbout.cpp
@@ -2,42 +2,13 @@
 #include "GUIMcaAbout.h"
 #include "res/resources.h"
 
-CGUIMcaAbout::CGUIMcaAbout(float x, float y)
-{
-	m_x = x;
-	m_y = y;
-}
-
-CGUIMcaAbout::CGUIMcaAbout(void)
+CGUIMcaAbout::CGUIMcaAbout(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y)
+	: CGUIMcaPopup(renderer, input, timer, x, y)
 {
 }
-
 
 CGUIMcaAbout::~CGUIMcaAbout(void)
 {
-}
-
-void CGUIMcaAbout::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out)
-{
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
-
-	float alpha = 0.0f;
-	u32 ticks = 0;
-	do
-	{
-		ticks = currTick - oldTick;
-		alpha = (float)ticks/(float)ms;
-		if (alpha > 1.0f) alpha = 1.0f;
-		if (out) alpha = 1.0f - alpha;
-
-		drawAll(prevBuffTex, alpha);
-		m_renderer->swapBuffers();
-
-		currTick = timer->getTicks();
-	} while (ticks <= ms);
-	drawAll(prevBuffTex, alpha);
-	m_renderer->swapBuffers();
 }
 
 void CGUIMcaAbout::drawMessage(float alpha)
@@ -98,43 +69,40 @@ void CGUIMcaAbout::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 	drawMessage(alpha);
 }
 
-int CGUIMcaAbout::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur)
+int CGUIMcaAbout::display(bool blur)
 {
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-	m_renderer = renderer;
-	m_input = input;
-	m_timer = timer;
+	u32 state_new = 0;
+	u32 state_all = 0;
 
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
-		prevBuffTex = renderer->getFrameTex(1);
+		prevBuffTex = m_renderer->getFrameTex(1);
 		prevBuffTex->blur(0);
 		prevBuffTex->blur(0);
 	} else
 	{
-		prevBuffTex = renderer->getFrameTex();
+		prevBuffTex = m_renderer->getFrameTex();
 	}
-	m_ticks = 0;
-	fadeInOut(prevBuffTex, timer, 25000, false);
+	u32 ticks = 0;
+	fadeInOut(prevBuffTex, 25000, false);
 	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
+	currTick = oldTick = m_timer->getTicks();
 	do
 	{
-		m_ticks = currTick - oldTick;
-		input->update();
-		m_input_state_new = input->getNew(m_ticks);
-		m_input_state_all = input->getAll();
+		ticks = currTick - oldTick;
+		m_input->update();
+		state_new = m_input->getNew(ticks);
+		state_all = m_input->getAll();
 
 		drawAll(prevBuffTex);
 		m_renderer->swapBuffers();
 
 		oldTick = currTick;
-		currTick = timer->getTicks();
+		currTick = m_timer->getTicks();
 
-	} while (m_input_state_new == 0);
-	fadeInOut(prevBuffTex, timer, 25000, true);
+	} while (state_new == 0);
+	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
 

--- a/MCA/GUIMcaAbout.cpp
+++ b/MCA/GUIMcaAbout.cpp
@@ -41,9 +41,7 @@ void CGUIMcaAbout::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *ti
 }
 
 void CGUIMcaAbout::drawMessage(float alpha)
-{
-	std::string formatted = CResources::mainLang.getText("LNG_WARN_NO_CARD_IN_SLOT");
-	
+{	
 	CResources::headerFont.printUTF8BoxShadow(
 		CResources::mainLang.getText("LNG_INFO_THX_CAP")
 		, m_x+8, m_y+15

--- a/MCA/GUIMcaAbout.h
+++ b/MCA/GUIMcaAbout.h
@@ -7,17 +7,12 @@ class CGUIMcaAbout :
 	public CGUIMcaPopup
 {
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
-	CGUIMcaAbout(void);
 public:
-	CGUIMcaAbout(float x, float y);
+	CGUIMcaAbout(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y);
 	~CGUIMcaAbout(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCAABOUT_H_

--- a/MCA/GUIMcaBaseWindow.cpp
+++ b/MCA/GUIMcaBaseWindow.cpp
@@ -1,0 +1,36 @@
+#include "GUIMcaBaseWindow.h"
+
+void CGUIMcaBaseWindow::fadeInOut(CIGUIFrameTexture* prevBuffTex, u32 ms, bool out)
+{
+	u32 currTick = 0, oldTick = 0;
+	currTick = oldTick = m_timer->getTicks();
+
+	float alpha = 0.0f;
+	u32 ticks = 0;
+	do
+	{
+		ticks = currTick - oldTick;
+		alpha = (float)ticks / (float)ms;
+		if (alpha > 1.0f) alpha = 1.0f;
+		if (out) alpha = 1.0f - alpha;
+
+		drawAll(prevBuffTex, alpha);
+		m_renderer->swapBuffers();
+
+		currTick = m_timer->getTicks();
+	} while (ticks <= ms);
+	drawAll(prevBuffTex, alpha);
+	m_renderer->swapBuffers();
+}
+
+CGUIMcaBaseWindow::CGUIMcaBaseWindow(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y)
+	: m_x(x)
+	, m_y(y)
+	, m_renderer(renderer)
+	, m_input(input)
+	, m_timer(timer)
+{
+}
+CGUIMcaBaseWindow::~CGUIMcaBaseWindow()
+{
+}

--- a/MCA/GUIMcaBaseWindow.h
+++ b/MCA/GUIMcaBaseWindow.h
@@ -1,0 +1,25 @@
+#ifndef _GUIMCABASEWINDOW_H_
+#define _GUIMCABASEWINDOW_H_
+
+#include "IGUIFrameRenderer.h"
+#include "IGUIFrameInput.h"
+#include "IGUIFrameTimer.h"
+#include "GUITypes.h"
+
+class CGUIMcaBaseWindow
+{
+public:
+	virtual void drawAll(CIGUIFrameTexture* prevBuffTex = NULL, float alpha = 1.0f) = 0;
+	virtual void fadeInOut(CIGUIFrameTexture* prevBuffTex, u32 ms, bool out = false);
+protected:
+	float m_x;
+	float m_y;
+	CIGUIFrameRenderer* m_renderer;
+	CIGUIFrameInput* m_input;
+	CIGUIFrameTimer* m_timer;
+
+	CGUIMcaBaseWindow(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x = 0, float y = 0);
+	virtual ~CGUIMcaBaseWindow();
+};
+
+#endif //_GUIMCABASEWINDOW_H_

--- a/MCA/GUIMcaCardInfo.cpp
+++ b/MCA/GUIMcaCardInfo.cpp
@@ -3,44 +3,14 @@
 #include "res/resources.h"
 #include "GUIMcaMan.h"
 
-CGUIMcaCardInfo::CGUIMcaCardInfo(float x, float y)
+CGUIMcaCardInfo::CGUIMcaCardInfo(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y)
+	: CGUIMcaPopup(renderer, input, timer, x, y)
+	, m_psxmode(false)
 {
-	m_x = x;
-	m_y = y;
-	m_psxmode = false;
 }
-
-CGUIMcaCardInfo::CGUIMcaCardInfo(void)
-{
-	m_psxmode = false;
-}
-
 
 CGUIMcaCardInfo::~CGUIMcaCardInfo(void)
 {
-}
-
-void CGUIMcaCardInfo::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out)
-{
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
-
-	float alpha = 0.0f;
-	u32 ticks = 0;
-	do
-	{
-		ticks = currTick - oldTick;
-		alpha = (float)ticks/(float)ms;
-		if (alpha > 1.0f) alpha = 1.0f;
-		if (out) alpha = 1.0f - alpha;
-
-		drawAll(prevBuffTex, alpha);
-		m_renderer->swapBuffers();
-
-		currTick = timer->getTicks();
-	} while (ticks <= ms);
-	drawAll(prevBuffTex, alpha);
-	m_renderer->swapBuffers();
 }
 
 void CGUIMcaCardInfo::drawMessage(float alpha)
@@ -197,49 +167,46 @@ void CGUIMcaCardInfo::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 	drawMessage(alpha);
 }
 
-int CGUIMcaCardInfo::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur)
+int CGUIMcaCardInfo::display(bool blur)
 {
-	return displayInfo(renderer, input, timer, blur, 0, false);
+	return displayInfo(blur, 0, false);
 }
-int CGUIMcaCardInfo::displayInfo(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur, int oper_slot, bool psxmode)
+int CGUIMcaCardInfo::displayInfo(bool blur, int oper_slot, bool psxmode)
 {
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-	m_renderer = renderer;
-	m_input = input;
-	m_timer = timer;
+	u32 state_new = 0;
+	u32 state_all = 0;
 	m_psxmode = psxmode;
 	m_oper_slot = oper_slot;
 
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
-		prevBuffTex = renderer->getFrameTex(1);
+		prevBuffTex = m_renderer->getFrameTex(1);
 		prevBuffTex->blur(0);
 		prevBuffTex->blur(0);
 	} else
 	{
-		prevBuffTex = renderer->getFrameTex();
+		prevBuffTex = m_renderer->getFrameTex();
 	}
-	m_ticks = 0;
-	fadeInOut(prevBuffTex, timer, 25000, false);
+	u32 ticks = 0;
+	fadeInOut(prevBuffTex, 25000, false);
 	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
+	currTick = oldTick = m_timer->getTicks();
 	do
 	{
-		m_ticks = currTick - oldTick;
-		input->update();
-		m_input_state_new = input->getNew(m_ticks);
-		m_input_state_all = input->getAll();
+		ticks = currTick - oldTick;
+		m_input->update();
+		state_new = m_input->getNew(ticks);
+		state_all = m_input->getAll();
 
 		drawAll(prevBuffTex);
 		m_renderer->swapBuffers();
 
 		oldTick = currTick;
-		currTick = timer->getTicks();
+		currTick = m_timer->getTicks();
 
-	} while (m_input_state_new == 0);
-	fadeInOut(prevBuffTex, timer, 25000, true);
+	} while (state_new == 0);
+	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
 

--- a/MCA/GUIMcaCardInfo.h
+++ b/MCA/GUIMcaCardInfo.h
@@ -9,21 +9,17 @@ class CGUIMcaCardInfo :
 	public CGUIMcaPopup
 {
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	bool m_psxmode;
 	int m_oper_slot;
 	CIGUIFrameFont<CGUITexture>::eAlignment m_align;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
 	CGUIMcaCardInfo(void);
 public:
-	CGUIMcaCardInfo(float x, float y);
+	CGUIMcaCardInfo(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y);
 	~CGUIMcaCardInfo(void);
-	int displayInfo(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false, int oper_slot = 0, bool psxmode = false);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int displayInfo(bool blur = false, int oper_slot = 0, bool psxmode = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCAMCARDINFO_H_

--- a/MCA/GUIMcaDisplayMessage.cpp
+++ b/MCA/GUIMcaDisplayMessage.cpp
@@ -2,48 +2,18 @@
 #include "GUIMcaDisplayMessage.h"
 #include "res/resources.h"
 
-CGUIMcaDisplayMessage::CGUIMcaDisplayMessage(float x, float y, const char *message, const char *caption, enIconType icon, CIGUIFrameFont<CGUITexture>::eAlignment align)
-{
-	m_x = x;
-	m_y = y;
-	m_message = message;
-	m_caption = caption;
-	m_icon = icon;
-	m_align = align;
-}
+CGUIMcaDisplayMessage::CGUIMcaDisplayMessage(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, const char* message, const char* caption, enIconType icon, CIGUIFrameFont<CGUITexture>::eAlignment align)
+	: CGUIMcaPopup(renderer, input, timer, x, y)
+	, m_message(message)
+	, m_caption(caption)
+	, m_icon(icon)
+	, m_align(align)
 
-CGUIMcaDisplayMessage::CGUIMcaDisplayMessage(void)
-	: m_message(NULL)
-	, m_caption(NULL)
 {
 }
-
 
 CGUIMcaDisplayMessage::~CGUIMcaDisplayMessage(void)
 {
-}
-
-void CGUIMcaDisplayMessage::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out)
-{
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
-
-	float alpha = 0.0f;
-	u32 ticks = 0;
-	do
-	{
-		ticks = currTick - oldTick;
-		alpha = (float)ticks/(float)ms;
-		if (alpha > 1.0f) alpha = 1.0f;
-		if (out) alpha = 1.0f - alpha;
-
-		drawAll(prevBuffTex, alpha);
-		m_renderer->swapBuffers();
-
-		currTick = timer->getTicks();
-	} while (ticks <= ms);
-	drawAll(prevBuffTex, alpha);
-	m_renderer->swapBuffers();
 }
 
 void CGUIMcaDisplayMessage::drawMessage(float alpha)
@@ -117,43 +87,40 @@ void CGUIMcaDisplayMessage::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 	drawMessage(alpha);
 }
 
-int CGUIMcaDisplayMessage::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur)
+int CGUIMcaDisplayMessage::display(bool blur)
 {
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-	m_renderer = renderer;
-	m_input = input;
-	m_timer = timer;
+	u32 state_new = 0;
+	u32 state_all = 0;
 
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
-		prevBuffTex = renderer->getFrameTex(1);
+		prevBuffTex = m_renderer->getFrameTex(1);
 		prevBuffTex->blur(0);
 		prevBuffTex->blur(0);
 	} else
 	{
-		prevBuffTex = renderer->getFrameTex();
+		prevBuffTex = m_renderer->getFrameTex();
 	}
-	m_ticks = 0;
-	fadeInOut(prevBuffTex, timer, 25000, false);
+	u32 ticks = 0;
+	fadeInOut(prevBuffTex, 25000, false);
 	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
+	currTick = oldTick = m_timer->getTicks();
 	do
 	{
-		m_ticks = currTick - oldTick;
-		input->update();
-		m_input_state_new = input->getNew(m_ticks);
-		m_input_state_all = input->getAll();
+		ticks = currTick - oldTick;
+		m_input->update();
+		state_new = m_input->getNew(ticks);
+		state_all = m_input->getAll();
 
 		drawAll(prevBuffTex);
 		m_renderer->swapBuffers();
 
 		oldTick = currTick;
-		currTick = timer->getTicks();
+		currTick = m_timer->getTicks();
 
-	} while (m_input_state_new == 0);
-	fadeInOut(prevBuffTex, timer, 25000, true);
+	} while (state_new == 0);
+	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
 

--- a/MCA/GUIMcaDisplayMessage.h
+++ b/MCA/GUIMcaDisplayMessage.h
@@ -17,21 +17,17 @@ public:
 		enIcNone,
 	};
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	const char *m_message;
 	const char *m_caption;
 	enIconType m_icon;
 	CIGUIFrameFont<CGUITexture>::eAlignment m_align;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
 	CGUIMcaDisplayMessage(void);
 public:
-	CGUIMcaDisplayMessage(float x, float y, const char *message, const char *caption, enIconType icon = enIcNone, CIGUIFrameFont<CGUITexture>::eAlignment align = CIGUIFrameFont<CGUITexture>::etxAlignJustify);
+	CGUIMcaDisplayMessage(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x = 0, float y = 0, const char* message = NULL, const char* caption = NULL, enIconType icon = enIcNone, CIGUIFrameFont<CGUITexture>::eAlignment align = CIGUIFrameFont<CGUITexture>::etxAlignJustify);
 	~CGUIMcaDisplayMessage(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCADISPLAYMESSAGE_H_

--- a/MCA/GUIMcaGetPath.h
+++ b/MCA/GUIMcaGetPath.h
@@ -60,29 +60,27 @@ private:
 	int m_listChosen;
 	int m_listBegin;
 	int m_maskItems;
-	CGUIMcaHover *m_hover_files;
+	CGUIMcaHover m_hover_files;
 	CGUIMcaTip m_tips;
 	bool m_keyb_tip_shown;
 	bool m_mask_enabled;
 	std::vector<std::string> m_mask;
 	const char* m_caption;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMngrWnd(float alpha = 1.0f);
 	void drawBoxArea(float alpha = 1.0f);
 	void drawFilelist(float alpha = 1.0f);
 	void doTopLevel(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	void doSubLevel(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	bool checkMessagesTop(bool topdir = false);
-	CGUIMcaGetPath(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 public:
-	CGUIMcaGetPath(float x, float y, const char *defaultname);
+	CGUIMcaGetPath(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, const char *defaultname);
 	~CGUIMcaGetPath(void);
 	void enableMask(bool enable) { m_mask_enabled = enable; }
 	void clearMask();
 	void addMaskEntry(std::string mask);
-	int doGetName(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, std::string &ret, bool save = false, bool blur = false, const char *caption = NULL);
+	int doGetName(std::string &ret, bool save = false, bool blur = false, const char *caption = NULL);
 };
 
 #endif //_GUIMCAGETPATH_H_

--- a/MCA/GUIMcaGetSize.h
+++ b/MCA/GUIMcaGetSize.h
@@ -11,18 +11,16 @@ private:
 	u32 m_input_state_all;
 	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
 	int m_card_mbytes;
 	int m_card_mbytes_ret;
 	bool m_return;
-	CGUIMcaGetSize(void);
 	bool checkMessages();
 	u32 lzw(u32 val);
 public:
-	CGUIMcaGetSize(float x, float y, int defaultmbytes);
+	CGUIMcaGetSize(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, int defaultmbytes);
 	~CGUIMcaGetSize(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCAGETSIZE_H_

--- a/MCA/GUIMcaGetYesNo.cpp
+++ b/MCA/GUIMcaGetYesNo.cpp
@@ -2,29 +2,18 @@
 #include "GUIMcaGetYesNo.h"
 #include "res/resources.h"
 
-CGUIMcaGetYesNo::CGUIMcaGetYesNo(float x, float y, const char* message, int defaultpos)
-	: m_hover_yesno(NULL)
+CGUIMcaGetYesNo::CGUIMcaGetYesNo(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, const char* message, int defaultpos)
+	: CGUIMcaPopup(renderer, input, timer, x, y)
+	, m_result(defaultpos)
+	, m_default(defaultpos)
+	, m_return(false)
+	, m_message(message)
+	, m_hover_yesno(renderer, 222, 230, 150, 38, 0.5f, 100, 255, 255, 255, 32, 32, 32, 0.50f, 0.25f, true)
 {
-	m_x = x;
-	m_y = y;
-	m_default = m_result = defaultpos;
-	m_return = false;
-	m_message = message;
-	m_hover_yesno = new CGUIMcaHover(222, 230, 150, 38, 0.5f, 100, 255, 255, 255, 32, 32, 32, 0.50f, 0.25f, true);
 }
-
-CGUIMcaGetYesNo::CGUIMcaGetYesNo(void)
-	: m_hover_yesno(NULL)
-{
-	m_result = enresNo;
-	m_return = false;
-	m_message = "";
-}
-
 
 CGUIMcaGetYesNo::~CGUIMcaGetYesNo(void)
 {
-	if (m_hover_yesno) delete m_hover_yesno;
 }
 
 bool CGUIMcaGetYesNo::checkMessages()
@@ -35,44 +24,21 @@ bool CGUIMcaGetYesNo::checkMessages()
 	{
 		m_return = true;
 		m_result = enresNo;
-		if (m_hover_yesno) m_hover_yesno->setDest(m_x+222+20,m_y+232, true);
+		m_hover_yesno.setDest(m_x+222+20,m_y+232, true);
 	} else if (m_input_state_new & CIGUIFrameInput::enInCross)
 	{
 		m_return = true;
 	} else if (m_input_state_new & CIGUIFrameInput::enInLeft)
 	{
 		m_result = enresYes;
-		if (m_hover_yesno) m_hover_yesno->setDest(m_x+8+20,m_y+232);
+		m_hover_yesno.setDest(m_x+8+20,m_y+232);
 	} else if (m_input_state_new & CIGUIFrameInput::enInRight)
 	{
 		m_result = enresNo;
-		if (m_hover_yesno) m_hover_yesno->setDest(m_x+222+20,m_y+232);
+		m_hover_yesno.setDest(m_x+222+20,m_y+232);
 	}
 		
 	return windowCalled;
-}
-
-void CGUIMcaGetYesNo::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out)
-{
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
-
-	float alpha = 0.0f;
-	u32 ticks = 0;
-	do
-	{
-		ticks = currTick - oldTick;
-		alpha = (float)ticks/(float)ms;
-		if (alpha > 1.0f) alpha = 1.0f;
-		if (out) alpha = 1.0f - alpha;
-
-		drawAll(prevBuffTex, alpha);
-		m_renderer->swapBuffers();
-
-		currTick = timer->getTicks();
-	} while (ticks <= ms);
-	drawAll(prevBuffTex, alpha);
-	m_renderer->swapBuffers();
 }
 
 void CGUIMcaGetYesNo::drawMessage(float alpha)
@@ -86,7 +52,7 @@ void CGUIMcaGetYesNo::drawMessage(float alpha)
 		, 0, 0, 0, alpha
 	);
 
-	if (m_hover_yesno) m_hover_yesno->drawHover(m_renderer, m_ticks, alpha);
+	m_hover_yesno.drawHover(m_ticks, alpha);
 	CResources::headerFont.printUTF8BoxShadow(
 		CResources::mainLang.getText("LNG_OPER_YES")
 		, m_x+8, m_y+230
@@ -119,48 +85,42 @@ void CGUIMcaGetYesNo::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 	drawMessage(alpha);
 }
 
-int CGUIMcaGetYesNo::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur)
+int CGUIMcaGetYesNo::display(bool blur)
 {
 	m_result = m_default;
 	m_input_state_new = 0;
 	m_input_state_all = 0;
-	m_renderer = renderer;
-	m_input = input;
-	m_timer = timer;
 
-	if (m_hover_yesno)
-	{
-		if (m_result == enresNo)
-			m_hover_yesno->setDest(m_x+222+20,m_y+232, true);
-		else
-			m_hover_yesno->setDest(m_x+8+20,m_y+232, true);
-	}
+	if (m_result == enresNo)
+		m_hover_yesno.setDest(m_x+222+20,m_y+232, true);
+	else
+		m_hover_yesno.setDest(m_x+8+20,m_y+232, true);
 
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
-		prevBuffTex = renderer->getFrameTex(1);
+		prevBuffTex = m_renderer->getFrameTex(1);
 		prevBuffTex->blur(0);
 		prevBuffTex->blur(0);
 	} else
 	{
-		prevBuffTex = renderer->getFrameTex();
+		prevBuffTex = m_renderer->getFrameTex();
 	}
 
 	m_ticks = 0;
-	fadeInOut(prevBuffTex, timer, 25000, false);
+	fadeInOut(prevBuffTex, 25000, false);
 	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
+	currTick = oldTick = m_timer->getTicks();
 	do
 	{
 		m_ticks = currTick - oldTick;
-		input->update();
-		m_input_state_new = input->getNew(m_ticks);
-		m_input_state_all = input->getAll();
+		m_input->update();
+		m_input_state_new = m_input->getNew(m_ticks);
+		m_input_state_all = m_input->getAll();
 
 		if (checkMessages())
 		{
-			currTick = oldTick = timer->getTicks();
+			currTick = oldTick = m_timer->getTicks();
 			continue;
 		}
 
@@ -168,10 +128,10 @@ int CGUIMcaGetYesNo::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *inpu
 		m_renderer->swapBuffers();
 
 		oldTick = currTick;
-		currTick = timer->getTicks();
+		currTick = m_timer->getTicks();
 
 	} while ( !m_return );
-	fadeInOut(prevBuffTex, timer, 25000, true);
+	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
 

--- a/MCA/GUIMcaGetYesNo.h
+++ b/MCA/GUIMcaGetYesNo.h
@@ -12,14 +12,12 @@ private:
 	u32 m_input_state_all;
 	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
 	int m_result;
 	int m_default;
 	bool m_return;
 	const char *m_message;
-	CGUIMcaHover *m_hover_yesno;
-	CGUIMcaGetYesNo(void);
+	CGUIMcaHover m_hover_yesno;
 	bool checkMessages();
 public:
 	enum enResult
@@ -27,9 +25,9 @@ public:
 		enresNo = 0,
 		enresYes = 1,
 	};
-	CGUIMcaGetYesNo(float x, float y, const char* message, int defaultpos = enresNo);
+	CGUIMcaGetYesNo(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, const char* message, int defaultpos = enresNo);
 	~CGUIMcaGetYesNo(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCAGETYESNO_H_

--- a/MCA/GUIMcaHover.cpp
+++ b/MCA/GUIMcaHover.cpp
@@ -1,36 +1,19 @@
 #include "GUIMcaHover.h"
 
 #define HOV_ALPHAMIN 0.10f
-CGUIMcaHover::CGUIMcaHover(void)
+
+CGUIMcaHover::CGUIMcaHover(CIGUIFrameRenderer* renderer, float x, float y, float w, float h, float divpoint, u32 speed_ms, u8 r, u8 g, u8 b, u8 br, u8 bg, u8 bb, float alpha, float balpha, bool visible)
+	: m_x(x), m_y(y), m_w(w), m_h(h), m_dx(x), m_dy(y)
+	, m_divpoint(divpoint)
+	, m_speed(speed_ms), m_speed_cur(speed_ms)
+	, m_r(r), m_g(g), m_b(b), m_alpha(alpha)
+	, m_br(br), m_bg(bg), m_bb(bb), m_balpha(balpha)
+	, m_visible(visible)
+	, m_astate(HOV_ALPHAMIN)
+	, m_aspd(60000)
+	, m_areverse(false)
+	, m_renderer(renderer)
 {
-}
-
-CGUIMcaHover::CGUIMcaHover(float x, float y, float w, float h, float divpoint, u32 speed_ms, u8 r, u8 g, u8 b, u8 br, u8 bg, u8 bb, float alpha, float balpha, bool visible)
-{
-	m_x = m_dx = x;
-	m_y = m_dy = y;
-	m_w = w;
-	m_h = h;
-
-	m_divpoint = divpoint;
-
-	m_speed = m_speed_cur = speed_ms;
-
-	m_r = r;
-	m_g = g;
-	m_b = b;
-	m_alpha = alpha;
-
-	m_br = br;
-	m_bg = bg;
-	m_bb = bb;
-	m_balpha = balpha;
-
-	m_visible = visible;
-
-	m_astate = HOV_ALPHAMIN;
-	m_aspd = 60000;
-	m_areverse = false;
 }
 
 void CGUIMcaHover::setDest(float dx, float dy, bool instantly)
@@ -50,7 +33,7 @@ void CGUIMcaHover::setDest(float dx, float dy, bool instantly)
 	}
 }
 
-void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alpha)
+void CGUIMcaHover::drawHover(u32 ticks, float alpha)
 {
 	if (!m_visible) return;
 
@@ -107,7 +90,7 @@ void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alph
 	}
 	//finally draw the thing
 	//top border
-	renderer->drawQuadG(
+	m_renderer->drawQuadG(
 		m_x, m_y -2.0f,
 		m_x+ m_divpoint*m_w, m_y -2.0f,
 		m_x, m_y,
@@ -118,7 +101,7 @@ void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alph
 		m_br, m_bg, m_bb,
 		0, m_balpha *m_astate*alpha, 0, m_balpha *m_astate*alpha
 	);
-	renderer->drawQuadG(
+	m_renderer->drawQuadG(
 		m_x+ m_divpoint*m_w, m_y -2.0f,
 		m_x+ m_w, m_y -2.0f,
 		m_x+ m_divpoint*m_w, m_y,
@@ -130,7 +113,7 @@ void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alph
 		m_balpha *m_astate*alpha, 0, m_balpha *m_astate*alpha, 0
 	);
 	//center
-	renderer->drawQuadG(
+	m_renderer->drawQuadG(
 		m_x, m_y,
 		m_x+ m_divpoint*m_w, m_y,
 		m_x, m_y+m_h,
@@ -141,7 +124,7 @@ void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alph
 		m_r, m_g, m_b,
 		0, m_alpha *m_astate*alpha, 0, m_alpha *m_astate*alpha
 	);
-	renderer->drawQuadG(
+	m_renderer->drawQuadG(
 		m_x+ m_divpoint*m_w, m_y,
 		m_x+ m_w, m_y,
 		m_x+ m_divpoint*m_w, m_y+m_h,
@@ -153,7 +136,7 @@ void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alph
 		m_alpha *m_astate*alpha, 0, m_alpha *m_astate*alpha, 0
 	);
 	//bottom border
-	renderer->drawQuadG(
+	m_renderer->drawQuadG(
 		m_x, m_y +m_h,
 		m_x+ m_divpoint*m_w, m_y +m_h,
 		m_x, m_y+2.0f +m_h,
@@ -164,7 +147,7 @@ void CGUIMcaHover::drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alph
 		m_br, m_bg, m_bb,
 		0, m_balpha *m_astate*alpha, 0, m_balpha *m_astate*alpha
 	);
-	renderer->drawQuadG(
+	m_renderer->drawQuadG(
 		m_x+ m_divpoint*m_w, m_y +m_h,
 		m_x+ m_w, m_y +m_h,
 		m_x+ m_divpoint*m_w, m_y+2.0f +m_h,

--- a/MCA/GUIMcaHover.h
+++ b/MCA/GUIMcaHover.h
@@ -6,7 +6,6 @@
 class CGUIMcaHover
 {
 private:
-	CGUIMcaHover(void);
 	float m_x;
 	float m_y;
 	float m_w;
@@ -29,12 +28,14 @@ private:
 	bool m_visible;
 	float m_cstate; u32 m_cspd; bool m_creverse;//for color blinking
 	float m_astate; u32 m_aspd; bool m_areverse;//for alpha blinking
+
+	CIGUIFrameRenderer* m_renderer;
 public:
-	CGUIMcaHover(float x, float y, float w, float h, float divpoint, u32 speed_ms, u8 r, u8 g, u8 b, u8 br, u8 bg, u8 bb, float alpha, float balpha, bool visible);
+	CGUIMcaHover(CIGUIFrameRenderer* renderer, float x, float y, float w, float h, float divpoint, u32 speed_ms, u8 r, u8 g, u8 b, u8 br, u8 bg, u8 bb, float alpha, float balpha, bool visible);
 	virtual ~CGUIMcaHover(void);
 
 	virtual void setDest(float dx, float dy, bool instantly = false);
-	virtual void drawHover(CIGUIFrameRenderer *renderer, u32 ticks, float alpha);
+	virtual void drawHover(u32 ticks, float alpha);
 	void setVisibility(bool value) { m_visible = value; }
 };
 

--- a/MCA/GUIMcaMainWnd.h
+++ b/MCA/GUIMcaMainWnd.h
@@ -2,21 +2,20 @@
 #define _GUIMCAMAINWND_H_
 
 #include "IGUIFrameWindow.h"
+#include "GUIMcaBaseWindow.h"
 #include "GUITypes.h"
 #include "GUIMcaHover.h"
 #include "GUIMcaOperWnd.h"
 
 class CGUIMcaMainWnd :
-	public CIGUIFrameWindow
+	public CIGUIFrameWindow,
+	public CGUIMcaBaseWindow
 {
 private:
 	int m_slot_chosen;
 	u32 m_input_state_new;
 	u32 m_input_state_all;
 	u32 m_ticks;
-	CIGUIFrameRenderer *m_renderer;
-	CIGUIFrameInput *m_input;
-	CIGUIFrameTimer *m_timer;
 
 	//CGUITexture m_bgimage;
 	CGUITexture m_slot[2];
@@ -64,16 +63,15 @@ private:
 
 	bool checkMessages();
 
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	void drawBackground(float alpha = 1.0f);
 	void drawSlots(float alpha = 1.0f);
 	void drawMcIcons(float alpha = 1.0f);
 	void drawChoseSlot(float alpha = 1.0f);
 public:
-	CGUIMcaMainWnd(void);
+	CGUIMcaMainWnd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer);
 	~CGUIMcaMainWnd(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCAMAINWND_H_

--- a/MCA/GUIMcaOperProgress.h
+++ b/MCA/GUIMcaOperProgress.h
@@ -12,28 +12,26 @@ private:
 	u32 m_input_state_all;
 	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
 	int m_result;
 	int m_default;
 	bool m_return;
 	bool m_locked;
-	CGUIMcaProgressBar *m_progressBar;
-	CGUIMcaOperProgress(void);
+	CGUIMcaProgressBar m_progressBar;
 	bool checkMessages();
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 public:
 	enum enResult
 	{
 		enresFail = 0,
 		enresSuccess = 1,
 	};
-	CGUIMcaOperProgress(float x, float y);
+	CGUIMcaOperProgress(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y);
 	~CGUIMcaOperProgress(void);
-	int doFormat(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, int slot, bool fast, bool psx, int pagestotal, bool blur = false);
-	int doUnformat(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, int slot, bool psx, int pagestotal, bool blur = false);
-	int doCreateImage(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, int slot, bool psx, int pagestotal, const char* path, bool blur = false);
-	int doRestoreImage(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, int slot, bool psx, const char *path, bool blur = false);
+	int doFormat(int slot, bool fast, bool psx, int pagestotal, bool blur = false);
+	int doUnformat(int slot, bool psx, int pagestotal, bool blur = false);
+	int doCreateImage(int slot, bool psx, int pagestotal, const char* path, bool blur = false);
+	int doRestoreImage(int slot, bool psx, const char *path, bool blur = false);
 };
 
 #endif //_GUIMCAOPERPROGRESS_H_

--- a/MCA/GUIMcaOperWnd.cpp
+++ b/MCA/GUIMcaOperWnd.cpp
@@ -32,8 +32,8 @@ bool CGUIMcaOperWnd::checkMessages()
 
 	if ((m_psx_mode && (CGUIMcaMan::mce_memcards[m_oper_slot].type != CGUIMcaMan::enctPsx && CGUIMcaMan::mce_memcards[m_oper_slot].type != CGUIMcaMan::enctPda)) || (!m_psx_mode && CGUIMcaMan::mce_memcards[m_oper_slot].type != CGUIMcaMan::enctPs2))
 	{
-		CGUIMcaWarrningNoCard myWarn(110, 106, m_oper_slot);
-		myWarn.display(m_renderer, m_input, m_timer, true);
+		CGUIMcaWarrningNoCard myWarn(m_renderer, m_input, m_timer, 110, 106, m_oper_slot);
+		myWarn.display(true);
 		m_exit_now = true;
 		windowCalled = true;
 		return windowCalled;
@@ -67,15 +67,15 @@ bool CGUIMcaOperWnd::checkMessages()
 
 	if (m_input_state_new & CIGUIFrameInput::enInSelect)
 	{
-		CGUIMcaCardInfo myCardInfo(138, 166);
-		myCardInfo.displayInfo(m_renderer, m_input, m_timer, true, m_oper_slot, m_psx_mode);
+		CGUIMcaCardInfo myCardInfo(m_renderer, m_input, m_timer, 138, 166);
+		myCardInfo.displayInfo(true, m_oper_slot, m_psx_mode);
 		windowCalled = true;
 		return windowCalled;
 	}
 	else if (m_input_state_new & CIGUIFrameInput::enInStart)
 	{
-		CGUIMcaAbout myAbout(110, 106);
-		myAbout.display(m_renderer, m_input, m_timer, true);
+		CGUIMcaAbout myAbout(m_renderer, m_input, m_timer, 110, 106);
+		myAbout.display(true);
 		windowCalled = true;
 	}
 
@@ -92,14 +92,14 @@ bool CGUIMcaOperWnd::checkMessages()
 				if (!m_psx_mode)
 				{
 					int defaultsize = CGUIMcaMan::mce_memcards[m_oper_slot].totalPages * CGUIMcaMan::mce_memcards[m_oper_slot].pageSize / 1024 / 1024;
-					CGUIMcaGetSize getCardSize(110, 106, defaultsize);//change to real size
-					cardSize = getCardSize.display(m_renderer, m_input, m_timer, true);
+					CGUIMcaGetSize getCardSize(m_renderer, m_input, m_timer, 110, 106, defaultsize);//change to real size
+					cardSize = getCardSize.display(true);
 
 					if (cardSize != -1 && cardSize > defaultsize)
 					{
 						int resYesNo;
-						CGUIMcaGetYesNo getYesNo(110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_SIZE_MISMATCH"), CGUIMcaGetYesNo::enresNo);
-						if ((resYesNo = getYesNo.display(m_renderer, m_input, m_timer, m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresNo)
+						CGUIMcaGetYesNo getYesNo(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_SIZE_MISMATCH"), CGUIMcaGetYesNo::enresNo);
+						if ((resYesNo = getYesNo.display(m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresNo)
 							skip = true;
 					}
 				}
@@ -108,16 +108,16 @@ bool CGUIMcaOperWnd::checkMessages()
 					int resYesNo;
 					if (!skip)
 					{
-						CGUIMcaGetYesNo getYesNo(110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_FORMAT_DATA_LOST"), CGUIMcaGetYesNo::enresNo);
-						if ((resYesNo = getYesNo.display(m_renderer, m_input, m_timer, m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresYes)
+						CGUIMcaGetYesNo getYesNo(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_FORMAT_DATA_LOST"), CGUIMcaGetYesNo::enresNo);
+						if ((resYesNo = getYesNo.display(m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresYes)
 						{
 							//here call format progress
 							if (!m_psx_mode)
 							{
 								totalpages = (cardSize * 1024 * 1024) / CGUIMcaMan::mce_memcards[m_oper_slot].pageSize;
 							}
-							CGUIMcaOperProgress formatProgress(110, 106);
-							formatProgress.doFormat(m_renderer, m_input, m_timer, m_oper_slot, m_menu_item_format == 0 ? true : false, m_psx_mode, totalpages);
+							CGUIMcaOperProgress formatProgress(m_renderer, m_input, m_timer, 110, 106);
+							formatProgress.doFormat(m_oper_slot, m_menu_item_format == 0 ? true : false, m_psx_mode, totalpages);
 							m_exit_now = true;
 						}
 					}
@@ -134,14 +134,14 @@ bool CGUIMcaOperWnd::checkMessages()
 				if (!m_psx_mode)
 				{
 					int defaultsize = CGUIMcaMan::mce_memcards[m_oper_slot].totalPages * CGUIMcaMan::mce_memcards[m_oper_slot].pageSize / 1024 / 1024;
-					CGUIMcaGetSize getCardSize(110, 106, defaultsize);//change to real size
-					cardSize = getCardSize.display(m_renderer, m_input, m_timer, true);
+					CGUIMcaGetSize getCardSize(m_renderer, m_input, m_timer, 110, 106, defaultsize);//change to real size
+					cardSize = getCardSize.display(true);
 
 					if (cardSize != -1 && cardSize > defaultsize)
 					{
 						int resYesNo;
-						CGUIMcaGetYesNo getYesNo(110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_SIZE_MISMATCH"), CGUIMcaGetYesNo::enresNo);
-						if ((resYesNo = getYesNo.display(m_renderer, m_input, m_timer, m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresNo)
+						CGUIMcaGetYesNo getYesNo(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_SIZE_MISMATCH"), CGUIMcaGetYesNo::enresNo);
+						if ((resYesNo = getYesNo.display(m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresNo)
 							skip = true;
 					}
 				}
@@ -150,16 +150,16 @@ bool CGUIMcaOperWnd::checkMessages()
 					int resYesNo;
 					if (!skip)
 					{
-						CGUIMcaGetYesNo getYesNo(110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_UNFORMAT_DATA_LOST"), CGUIMcaGetYesNo::enresNo);
-						if ((resYesNo = getYesNo.display(m_renderer, m_input, m_timer, m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresYes)
+						CGUIMcaGetYesNo getYesNo(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_UNFORMAT_DATA_LOST"), CGUIMcaGetYesNo::enresNo);
+						if ((resYesNo = getYesNo.display(m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresYes)
 						{
 							//here call format progress
 							if (!m_psx_mode)
 							{
 								totalpages = (cardSize * 1024 * 1024) / CGUIMcaMan::mce_memcards[m_oper_slot].pageSize;
 							}
-							CGUIMcaOperProgress unformatProgress(110, 106);
-							unformatProgress.doUnformat(m_renderer, m_input, m_timer, m_oper_slot, m_psx_mode, totalpages);
+							CGUIMcaOperProgress unformatProgress(m_renderer, m_input, m_timer, 110, 106);
+							unformatProgress.doUnformat(m_oper_slot, m_psx_mode, totalpages);
 							m_exit_now = true;
 						}
 					}
@@ -175,8 +175,8 @@ bool CGUIMcaOperWnd::checkMessages()
 				if (!m_psx_mode)
 				{
 					int defaultsize = CGUIMcaMan::mce_memcards[m_oper_slot].totalPages * CGUIMcaMan::mce_memcards[m_oper_slot].pageSize / 1024 / 1024;
-					CGUIMcaGetSize getCardSize(110, 106, defaultsize);//change to real size
-					cardSize = getCardSize.display(m_renderer, m_input, m_timer, true);
+					CGUIMcaGetSize getCardSize(m_renderer, m_input, m_timer, 110, 106, defaultsize);//change to real size
+					cardSize = getCardSize.display(true);
 				}
 				if (cardSize != -1)
 				{
@@ -189,7 +189,7 @@ bool CGUIMcaOperWnd::checkMessages()
 						defname += ".mcr";
 					else
 						defname += ".bin";
-					CGUIMcaGetPath getPath(67, 106, defname.c_str());
+					CGUIMcaGetPath getPath(m_renderer, m_input, m_timer, 67, 106, defname.c_str());
 					if (m_psx_mode)
 					{
 						getPath.addMaskEntry(".mcr");
@@ -205,7 +205,7 @@ bool CGUIMcaOperWnd::checkMessages()
 					}
 					getPath.enableMask(true);
 					std::string result;
-					getPath.doGetName(m_renderer, m_input, m_timer, result, true, m_psx_mode ? true : false);
+					getPath.doGetName(result, true, m_psx_mode ? true : false);
 
 					//here call create image progress
 					if (!result.empty())
@@ -228,8 +228,8 @@ bool CGUIMcaOperWnd::checkMessages()
 						{
 							fioClose(chkfd);
 							int resYesNo;
-							CGUIMcaGetYesNo getYesNo(110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_OVERWRITE"), CGUIMcaGetYesNo::enresNo);
-							if ((resYesNo = getYesNo.display(m_renderer, m_input, m_timer, m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresNo)
+							CGUIMcaGetYesNo getYesNo(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_OVERWRITE"), CGUIMcaGetYesNo::enresNo);
+							if ((resYesNo = getYesNo.display(m_psx_mode ? true : false)) == CGUIMcaGetYesNo::enresNo)
 							{
 								windowCalled = true;
 								return windowCalled;
@@ -240,8 +240,8 @@ bool CGUIMcaOperWnd::checkMessages()
 						{
 							totalpages = (cardSize * 1024 * 1024) / CGUIMcaMan::mce_memcards[m_oper_slot].pageSize;
 						}
-						CGUIMcaOperProgress createProgress(110, 106);
-						createProgress.doCreateImage(m_renderer, m_input, m_timer, m_oper_slot, m_psx_mode, totalpages, result.c_str(), false);
+						CGUIMcaOperProgress createProgress(m_renderer, m_input, m_timer, 110, 106);
+						createProgress.doCreateImage(m_oper_slot, m_psx_mode, totalpages, result.c_str(), false);
 						if (result.substr(0, 5) == "hdd0:") fileXioUmount("pfs0:");
 						m_exit_now = true;
 					}
@@ -255,7 +255,7 @@ bool CGUIMcaOperWnd::checkMessages()
 				std::string defname = "memorycard";
 				defname += m_oper_slot;
 				defname += ".bin";
-				CGUIMcaGetPath getPath(67, 106, defname.c_str());
+				CGUIMcaGetPath getPath(m_renderer, m_input, m_timer, 67, 106, defname.c_str());
 				if (m_psx_mode)
 				{
 					getPath.addMaskEntry(".mcr");
@@ -271,18 +271,18 @@ bool CGUIMcaOperWnd::checkMessages()
 				}
 				getPath.enableMask(true);
 				std::string result;
-				getPath.doGetName(m_renderer, m_input, m_timer, result, false, true);
+				getPath.doGetName(result, false, true);
 
 				//here call create image progress
 				if (!result.empty())
 				{
 					int resYesNo;
-					CGUIMcaGetYesNo getYesNo(110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_RESTORE_DATA_LOST"), CGUIMcaGetYesNo::enresNo);
-					if ((resYesNo = getYesNo.display(m_renderer, m_input, m_timer, false)) == CGUIMcaGetYesNo::enresYes)
+					CGUIMcaGetYesNo getYesNo(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_OPER_QUESTION_RESTORE_DATA_LOST"), CGUIMcaGetYesNo::enresNo);
+					if ((resYesNo = getYesNo.display(false)) == CGUIMcaGetYesNo::enresYes)
 					{
 						//here call restore progress
-						CGUIMcaOperProgress restoreProgress(110, 106);
-						restoreProgress.doRestoreImage(m_renderer, m_input, m_timer, m_oper_slot, m_psx_mode, result.c_str(), false);
+						CGUIMcaOperProgress restoreProgress(m_renderer, m_input, m_timer, 110, 106);
+						restoreProgress.doRestoreImage(m_oper_slot, m_psx_mode, result.c_str(), false);
 						if (result.substr(0, 5) == "hdd0:") fileXioUmount("pfs0:");
 						m_exit_now = true;
 					}
@@ -293,8 +293,8 @@ bool CGUIMcaOperWnd::checkMessages()
 			break;
 			case 4://card info
 			{
-				CGUIMcaCardInfo myCardInfo(138, 166);
-				myCardInfo.displayInfo(m_renderer, m_input, m_timer, true, m_oper_slot, m_psx_mode);
+				CGUIMcaCardInfo myCardInfo(m_renderer, m_input, m_timer, 138, 166);
+				myCardInfo.displayInfo(m_oper_slot, m_psx_mode);
 				windowCalled = true;
 				return windowCalled;
 			}
@@ -313,14 +313,14 @@ void CGUIMcaOperWnd::setOperSlot(int operslot)
 	m_oper_slot = operslot;
 }
 
-CGUIMcaOperWnd::CGUIMcaOperWnd(void)
-	: m_psx_mode(false)
+CGUIMcaOperWnd::CGUIMcaOperWnd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer)
+	: CGUIMcaBaseWindow(renderer, input, timer, 0, 0)
+	, m_menu_item(0)
+	, m_menu_item_format(0)
+	, m_psx_mode(false)
 	, m_exit_now(false)
-	, m_hover_menu(70, 248, 450, 24, 0.1f, 600, 255, 255, 255, 32, 32, 32, 0.50f, 0.25f, true)
+	, m_hover_menu(renderer, 70, 248, 450, 24, 0.1f, 600, 255, 255, 255, 32, 32, 32, 0.50f, 0.25f, true)
 {
-	m_menu_item = 0;
-	m_menu_item_format = 0;
-
 	CResources::m_bgimage.loadTextureBuffer(CResources::bgimg_tm2, CResources::size_bgimg_tm2, true);
 	CResources::m_popup_pal.loadTextureBuffer(CResources::popup_pal_tm2, CResources::size_popup_pal_tm2, true);
 
@@ -333,29 +333,6 @@ CGUIMcaOperWnd::~CGUIMcaOperWnd(void)
 {
 }
 
-void CGUIMcaOperWnd::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out)
-{
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
-
-	float alpha = 0.0f;
-	u32 ticks = 0;
-	do
-	{
-		ticks = currTick - oldTick;
-		alpha = (float)ticks/(float)ms;
-		if (alpha > 1.0f) alpha = 1.0f;
-		if (out) alpha = 1.0f - alpha;
-
-		drawAll(prevBuffTex, alpha);
-		m_renderer->swapBuffers();
-
-		currTick = timer->getTicks();
-	} while (ticks <= ms);
-	drawAll(prevBuffTex, alpha);
-	m_renderer->swapBuffers();
-}
-
 void CGUIMcaOperWnd::drawBackground(float alpha)
 {
 	m_renderer->drawSpriteT(&CResources::m_bgimage, 0, 0, CResources::m_bgimage.getWidth(), CResources::m_bgimage.getHeight(), 0, 0, CResources::m_bgimage.getWidth(), CResources::m_bgimage.getHeight(), 128, 128, 128, alpha);
@@ -363,7 +340,7 @@ void CGUIMcaOperWnd::drawBackground(float alpha)
 
 void CGUIMcaOperWnd::drawMenu(float alpha)
 {
-	m_hover_menu.drawHover(m_renderer, m_ticks, alpha);
+	m_hover_menu.drawHover(m_ticks, alpha);
 
 	for (u32 i = 0; i < countof(m_menu_options); i++)
 	{
@@ -454,36 +431,33 @@ void CGUIMcaOperWnd::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 	drawMenu(alpha);
 }
 
-int CGUIMcaOperWnd::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur)
+int CGUIMcaOperWnd::display(bool blur)
 {
 	m_exit_now = false;
 	m_input_state_new = 0;
 	m_input_state_all = 0;
-	m_renderer = renderer;
-	m_input = input;
-	m_timer = timer;
 
 	m_menu_item = 0;
 	m_menu_item_format = 0;
 	m_hover_menu.setDest(70, 248 +26*m_menu_item, true);
 
-	CIGUIFrameTexture *prevBuffTex = renderer->getFrameTex();
+	CIGUIFrameTexture *prevBuffTex = m_renderer->getFrameTex();
 	m_ticks = 0;
 	checkMessages();
-	fadeInOut(prevBuffTex, timer, 25000, false);
+	fadeInOut(prevBuffTex, 25000, false);
 	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
+	currTick = oldTick = m_timer->getTicks();
 	do
 	{
 		if (m_exit_now) break;
 		m_ticks = currTick - oldTick;
-		input->update();
-		m_input_state_new = input->getNew(m_ticks);
-		m_input_state_all = input->getAll();
+		m_input->update();
+		m_input_state_new = m_input->getNew(m_ticks);
+		m_input_state_all = m_input->getAll();
 
 		if (checkMessages())
 		{
-			currTick = oldTick = timer->getTicks();
+			currTick = oldTick = m_timer->getTicks();
 			continue;
 		}
 
@@ -492,10 +466,10 @@ int CGUIMcaOperWnd::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input
 		m_renderer->swapBuffers();
 
 		oldTick = currTick;
-		currTick = timer->getTicks();
+		currTick = m_timer->getTicks();
 
 	} while ((m_input_state_new & CIGUIFrameInput::enInTriangle) == 0);
-	fadeInOut(prevBuffTex, timer, 25000, true);
+	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
 

--- a/MCA/GUIMcaOperWnd.h
+++ b/MCA/GUIMcaOperWnd.h
@@ -2,11 +2,13 @@
 #define _GUIMCAOPERWND_H_
 
 #include "IGUIFrameWindow.h"
+#include "GUIMcaBaseWindow.h"
 #include "GUITypes.h"
 #include "GUIMcaHover.h"
 
 class CGUIMcaOperWnd :
-	public CIGUIFrameWindow
+	public CIGUIFrameWindow,
+	public CGUIMcaBaseWindow
 {
 private:
 	int m_menu_item;
@@ -16,9 +18,6 @@ private:
 	u32 m_input_state_all;
 	u32 m_ticks;
 	bool m_psx_mode;
-	CIGUIFrameRenderer *m_renderer;
-	CIGUIFrameInput *m_input;
-	CIGUIFrameTimer *m_timer;
 	bool m_exit_now;
 
 	CGUITexture m_mca_logo;
@@ -32,15 +31,14 @@ private:
 
 	bool checkMessages();
 
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	void drawBackground(float alpha = 1.0f);
 	void drawStatic(float alpha = 1.0f);
 	void drawMenu(float alpha = 1.0f);
 public:
-	CGUIMcaOperWnd(void);
+	CGUIMcaOperWnd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer);
 	~CGUIMcaOperWnd(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 	void setPsxMode(bool psxmode = false);
 	void setOperSlot(int operslot);
 };

--- a/MCA/GUIMcaPopup.cpp
+++ b/MCA/GUIMcaPopup.cpp
@@ -2,9 +2,8 @@
 #include "res/resources.h"
 
 
-CGUIMcaPopup::CGUIMcaPopup(void)
-	: m_x(0.0f)
-	, m_y(0.0f)
+CGUIMcaPopup::CGUIMcaPopup(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y)
+	: CGUIMcaBaseWindow(renderer, input, timer, x, y)
 {
 	CResources::m_popup_pal.loadTextureBuffer(CResources::popup_pal_tm2, CResources::size_popup_pal_tm2, true);
 	CResources::m_popup_pal_info.loadTextureBuffer(CResources::popup_pal_info_tm2, CResources::size_popup_pal_info_tm2, true);

--- a/MCA/GUIMcaPopup.h
+++ b/MCA/GUIMcaPopup.h
@@ -1,27 +1,24 @@
 #ifndef _GUIMCAPOPUP_H_
 #define _GUIMCAPOPUP_H_
 
+#include "GUIMcaBaseWindow.h"
 #include "IGUIFrameRenderer.h"
 #include "IGUIFrameInput.h"
 #include "IGUIFrameTimer.h"
 #include "GUITypes.h"
 
-class CGUIMcaPopup
+class CGUIMcaPopup :
+	public CGUIMcaBaseWindow
 {
 protected:
-	float m_x;
-	float m_y;
-	CIGUIFrameRenderer *m_renderer;
-	CIGUIFrameInput *m_input;
-	CIGUIFrameTimer *m_timer;
 	void drawWindow(float alpha = 1.0f);
 	void drawWindowInfo(float alpha = 1.0f);
 	void drawExclam(float alpha = 1.0f);
 	void drawFail(float alpha = 1.0f);
 	void drawSuccess(float alpha = 1.0f);
 public:
-	virtual int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false) = 0;
-	CGUIMcaPopup(void);
+	virtual int display(bool blur = false) = 0;
+	CGUIMcaPopup(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x = 0, float y = 0);
 	virtual ~CGUIMcaPopup(void);
 };
 

--- a/MCA/GUIMcaProgressBar.cpp
+++ b/MCA/GUIMcaProgressBar.cpp
@@ -1,7 +1,15 @@
 #include "GUIMcaProgressBar.h"
 
 
-CGUIMcaProgressBar::CGUIMcaProgressBar(void)
+CGUIMcaProgressBar::CGUIMcaProgressBar(CIGUIFrameRenderer* renderer, float x, float y)
+	: m_x(x), m_y(y)
+	, m_progress(0.0f)
+	, m_r1(255), m_g1(133), m_b1(112)
+	, m_r2(244), m_g2(116), m_b2(94)
+	, m_r3(207), m_g3(31), m_b3(0)
+	, m_r4(149), m_g4(22), m_b4(0)
+	, m_state(ensPending)
+	, m_renderer(renderer)
 {
 	CResources::m_bar_red.loadTextureBuffer(CResources::progress_red_tm2, CResources::size_progress_red_tm2, true);
 	CResources::m_bar_green.loadTextureBuffer(CResources::progress_green_tm2, CResources::size_progress_green_tm2, true);
@@ -9,54 +17,6 @@ CGUIMcaProgressBar::CGUIMcaProgressBar(void)
 
 	CResources::m_bar_lead_green.loadTextureBuffer(CResources::progress_lead_green_tm2, CResources::size_progress_lead_green_tm2, true);
 	CResources::m_bar_lead_red.loadTextureBuffer(CResources::progress_lead_red_tm2, CResources::size_progress_lead_red_tm2, true);
-
-	m_x = 0.0f;
-	m_y = 0.0f;
-
-	m_r1 = 255;
-	m_g1 = 133;
-	m_b1 = 112;
-	m_r2 = 244;
-	m_g2 = 116;
-	m_b2 = 94;
-
-	m_r3 = 207;
-	m_g3 = 31;
-	m_b3 = 0;
-	m_r4 = 149;
-	m_g4 = 22;
-	m_b4 = 0;
-
-	m_state = ensPending;
-}
-
-CGUIMcaProgressBar::CGUIMcaProgressBar(float x, float y)
-{
-	CResources::m_bar_red.loadTextureBuffer(CResources::progress_red_tm2, CResources::size_progress_red_tm2, true);
-	CResources::m_bar_green.loadTextureBuffer(CResources::progress_green_tm2, CResources::size_progress_green_tm2, true);
-	CResources::m_bar_black.loadTextureBuffer(CResources::progress_black_tm2, CResources::size_progress_black_tm2, true);
-
-	CResources::m_bar_lead_green.loadTextureBuffer(CResources::progress_lead_green_tm2, CResources::size_progress_lead_green_tm2, true);
-	CResources::m_bar_lead_red.loadTextureBuffer(CResources::progress_lead_red_tm2, CResources::size_progress_lead_red_tm2, true);
-
-	m_x = x;
-	m_y = y;
-
-	m_r1 = 255;
-	m_g1 = 133;
-	m_b1 = 112;
-	m_r2 = 244;
-	m_g2 = 116;
-	m_b2 = 94;
-
-	m_r3 = 207;
-	m_g3 = 31;
-	m_b3 = 0;
-	m_r4 = 149;
-	m_g4 = 22;
-	m_b4 = 0;
-
-	m_state = ensPending;
 }
 
 
@@ -69,10 +29,10 @@ void CGUIMcaProgressBar::setState(enStateProgress state)
 	m_state = state;
 }
 
-void CGUIMcaProgressBar::display(CIGUIFrameRenderer *renderer, float alpha)
+void CGUIMcaProgressBar::display(float alpha)
 {
 	float shadowpos = 20.0f;
-	renderer->drawSpriteT(
+	m_renderer->drawSpriteT(
 		&CResources::m_bar_black
 		, m_x, m_y
 		, CResources::m_bar_black.getWidth(), CResources::m_bar_black.getHeight()
@@ -81,7 +41,7 @@ void CGUIMcaProgressBar::display(CIGUIFrameRenderer *renderer, float alpha)
 		, 128, 128, 128, alpha*0.18f
 	);
 
-	renderer->drawQuadGT(
+	m_renderer->drawQuadGT(
 		&CResources::m_bar_black
 		, m_x, m_y+shadowpos
 		, 0.5f, CResources::m_bar_black.getHeight()-0.5f
@@ -122,7 +82,7 @@ void CGUIMcaProgressBar::display(CIGUIFrameRenderer *renderer, float alpha)
 		{
 			if (362.0f*m_progress >= 3.0f && 362.0f*m_progress <= 361.0f)
 			{
-				renderer->drawSpriteT(
+				m_renderer->drawSpriteT(
 					state_lead
 					, m_x+3.0f -4.0f +362.0f*m_progress, m_y
 					, state_lead->getWidth(), state_lead->getHeight()
@@ -131,7 +91,7 @@ void CGUIMcaProgressBar::display(CIGUIFrameRenderer *renderer, float alpha)
 					, 128, 128, 128, alpha
 				);
 
-				renderer->drawQuadGT(
+				m_renderer->drawQuadGT(
 					state_lead
 					, m_x+3.0f -4.0f +362.0f*m_progress, m_y+shadowpos
 					, 0.5f, state_lead->getHeight()-0.5f
@@ -152,7 +112,7 @@ void CGUIMcaProgressBar::display(CIGUIFrameRenderer *renderer, float alpha)
 				);
 			}
 		}
-		renderer->drawSpriteT(
+		m_renderer->drawSpriteT(
 			state_bar
 			, m_x, m_y
 			, 3.0f + 362.0f*m_progress, state_bar->getHeight()
@@ -160,7 +120,7 @@ void CGUIMcaProgressBar::display(CIGUIFrameRenderer *renderer, float alpha)
 			, 3.0f + 362.0f*m_progress, state_bar->getHeight()
 			, 128, 128, 128, alpha
 		);
-		renderer->drawQuadGT(
+		m_renderer->drawQuadGT(
 			state_bar
 			, m_x, m_y+shadowpos
 			, 0.5f, state_bar->getHeight()-0.5f

--- a/MCA/GUIMcaProgressBar.h
+++ b/MCA/GUIMcaProgressBar.h
@@ -15,8 +15,6 @@ public:
 		ensFail,
 	};
 private:
-	CGUIMcaProgressBar(void);
-
 	float m_x;
 	float m_y;
 
@@ -29,10 +27,11 @@ private:
 	u8 m_r4; u8 m_g4; u8 m_b4;
 
 	enStateProgress m_state;
+	CIGUIFrameRenderer* m_renderer;
 public:
-	CGUIMcaProgressBar(float x, float y);
+	CGUIMcaProgressBar(CIGUIFrameRenderer* renderer, float x, float y);
 	virtual ~CGUIMcaProgressBar(void);
-	void display(CIGUIFrameRenderer *renderer, float alpha = 1.0f);
+	void display(float alpha = 1.0f);
 	void setProgress(float progress);
 	void setState(enStateProgress state);
 	void setColor(u8 r1, u8 g1, u8 b1, u8 r2, u8 g2, u8 b2, u8 r3, u8 g3, u8 b3, u8 r4, u8 g4, u8 b4);

--- a/MCA/GUIMcaTip.cpp
+++ b/MCA/GUIMcaTip.cpp
@@ -1,22 +1,14 @@
 #include "GUIMcaTip.h"
 #include "res/resources.h"
 
-CGUIMcaTip::CGUIMcaTip(void)
+CGUIMcaTip::CGUIMcaTip(CIGUIFrameRenderer* renderer, float x, float y, int time)
+	: m_x(x)
+	, m_y(y)
+	, m_fade_ticks_total(0)
+	, m_fade_ticks(time)
+	, m_visible(true)
+	, m_renderer(renderer)
 {
-	m_fade_ticks = 1;
-	m_fade_ticks_total = 0;
-
-	CResources::m_popup_tip.loadTextureBuffer(CResources::popup_tip_tm2, CResources::size_popup_tip_tm2, true);
-}
-
-CGUIMcaTip::CGUIMcaTip(float x, float y, int time)
-{
-	m_x = x;
-	m_y = y;
-	m_fade_ticks = time;
-	m_fade_ticks_total = 0;
-	m_visible = true;
-
 	CResources::m_popup_tip.loadTextureBuffer(CResources::popup_tip_tm2, CResources::size_popup_tip_tm2, true);
 }
 
@@ -25,7 +17,7 @@ void CGUIMcaTip::addTip(std::string message, u8 r, u8 g, u8 b, float a, u32 time
 	m_queue.push( t_entry(message, r, g, b, a, time, key_pressed) );
 }
 
-void CGUIMcaTip::drawTip(CIGUIFrameRenderer *renderer, u32 new_input, u32 ticks, float alpha)
+void CGUIMcaTip::drawTip(u32 new_input, u32 ticks, float alpha)
 {
 	if (!m_visible || m_queue.size() == 0) return;
 	float fadealpha = 0;
@@ -68,7 +60,7 @@ void CGUIMcaTip::drawTip(CIGUIFrameRenderer *renderer, u32 new_input, u32 ticks,
 	}
 	//finally draw the thing
 
-	renderer->drawSpriteT(
+	m_renderer->drawSpriteT(
 		&CResources::m_popup_tip,
 		m_x, m_y,
 		CResources::m_popup_tip.getWidth(), CResources::m_popup_tip.getHeight(),

--- a/MCA/GUIMcaTip.h
+++ b/MCA/GUIMcaTip.h
@@ -7,7 +7,6 @@
 class CGUIMcaTip
 {
 private:
-	CGUIMcaTip(void);
 	float m_x;
 	float m_y;
 	int m_fade_ticks_total;
@@ -32,11 +31,12 @@ private:
 	};
 	std::queue<t_entry> m_queue;
 	bool m_visible;
+	CIGUIFrameRenderer* m_renderer;
 public:
-	CGUIMcaTip(float x, float y, int time);
+	CGUIMcaTip(CIGUIFrameRenderer* renderer, float x, float y, int time);
 	virtual ~CGUIMcaTip(void);
 	virtual void addTip(std::string message, u8 r = 0, u8 g = 0, u8 b = 0, float a = 1.0f, u32 time = 25000, bool key_pressed = false);
-	virtual void drawTip(CIGUIFrameRenderer *renderer, u32 new_input, u32 ticks, float alpha);
+	virtual void drawTip(u32 new_input, u32 ticks, float alpha);
 	void setVisibility(bool value) { m_visible = value; }
 };
 

--- a/MCA/GUIMcaVkbd.h
+++ b/MCA/GUIMcaVkbd.h
@@ -6,9 +6,11 @@
 #include "IGUIFrameRenderer.h"
 #include "IGUIFrameInput.h"
 #include "IGUIFrameTimer.h"
+#include "GUIMcaBaseWindow.h"
 #include "GUITypes.h"
 
 class CGUIMcaVkbd
+	: public CGUIMcaBaseWindow
 {
 public:
 	struct t_key
@@ -48,17 +50,12 @@ private:
 	u32 m_max_chars;
 	bool m_display_caret;
 	u32 m_caret_ticks;
-	float m_x;
-	float m_y;
 	float m_curx;
 	float m_cury;
 	bool m_exit_now;
 	bool m_caps;
 	bool m_shift;
 	bool m_tmp_shift;
-	CIGUIFrameRenderer *m_renderer;
-	CIGUIFrameInput *m_input;
-	CIGUIFrameTimer *m_timer;
 	u32 m_input_state_new;
 	u32 m_input_state_all;
 	u32 m_ticks;
@@ -67,15 +64,13 @@ private:
 	void drawWindow(float alpha = 1.0f);
 	void drawCursor(float alpha = 1.0f);
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawText(float alpha = 1.0f);
 	void drawKeys(float alpha = 1.0f);
-	CGUIMcaVkbd(void);
 	bool checkMessages();
 public:
-	CGUIMcaVkbd(float x, float y);
+	CGUIMcaVkbd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y);
 	~CGUIMcaVkbd(void);
-	int getEntry(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, const char *defname, std::string &ret, u32 max_chars = 0, CIGUIFrameTexture *prevtex = NULL, bool blur = false, bool filename_mode = false);
+	int getEntry(const char *defname, std::string &ret, u32 max_chars = 0, CIGUIFrameTexture *prevtex = NULL, bool blur = false, bool filename_mode = false);
 };
 
 #endif //_GUIMCAVKBD_H_

--- a/MCA/GUIMcaWarrningNoCard.cpp
+++ b/MCA/GUIMcaWarrningNoCard.cpp
@@ -2,43 +2,14 @@
 #include "GUIMcaWarrningNoCard.h"
 #include "res/resources.h"
 
-CGUIMcaWarrningNoCard::CGUIMcaWarrningNoCard(float x, float y, int slotnum)
-{
-	m_x = x;
-	m_y = y;
-	m_slotnum = slotnum;
-}
-
-CGUIMcaWarrningNoCard::CGUIMcaWarrningNoCard(void)
+CGUIMcaWarrningNoCard::CGUIMcaWarrningNoCard(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, int slotnum)
+	: CGUIMcaPopup(renderer, input, timer, x, y)
+	, m_slotnum(slotnum)
 {
 }
-
 
 CGUIMcaWarrningNoCard::~CGUIMcaWarrningNoCard(void)
 {
-}
-
-void CGUIMcaWarrningNoCard::fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out)
-{
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
-
-	float alpha = 0.0f;
-	u32 ticks = 0;
-	do
-	{
-		ticks = currTick - oldTick;
-		alpha = (float)ticks/(float)ms;
-		if (alpha > 1.0f) alpha = 1.0f;
-		if (out) alpha = 1.0f - alpha;
-
-		drawAll(prevBuffTex, alpha);
-		m_renderer->swapBuffers();
-
-		currTick = timer->getTicks();
-	} while (ticks <= ms);
-	drawAll(prevBuffTex, alpha);
-	m_renderer->swapBuffers();
 }
 
 void CGUIMcaWarrningNoCard::drawMessage(float alpha)
@@ -68,43 +39,40 @@ void CGUIMcaWarrningNoCard::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 	drawMessage(alpha);
 }
 
-int CGUIMcaWarrningNoCard::display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur)
+int CGUIMcaWarrningNoCard::display(bool blur)
 {
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-	m_renderer = renderer;
-	m_input = input;
-	m_timer = timer;
+	u32 state_new = 0;
+	u32 state_all = 0;
 
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
-		prevBuffTex = renderer->getFrameTex(1);
+		prevBuffTex = m_renderer->getFrameTex(1);
 		prevBuffTex->blur(0);
 		prevBuffTex->blur(0);
 	} else
 	{
-		prevBuffTex = renderer->getFrameTex();
+		prevBuffTex = m_renderer->getFrameTex();
 	}
-	m_ticks = 0;
-	fadeInOut(prevBuffTex, timer, 25000, false);
+	u32 ticks = 0;
+	fadeInOut(prevBuffTex, 25000, false);
 	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = timer->getTicks();
+	currTick = oldTick = m_timer->getTicks();
 	do
 	{
-		m_ticks = currTick - oldTick;
-		input->update();
-		m_input_state_new = input->getNew(m_ticks);
-		m_input_state_all = input->getAll();
+		ticks = currTick - oldTick;
+		m_input->update();
+		state_new = m_input->getNew(ticks);
+		state_all = m_input->getAll();
 
 		drawAll(prevBuffTex);
 		m_renderer->swapBuffers();
 
 		oldTick = currTick;
-		currTick = timer->getTicks();
+		currTick = m_timer->getTicks();
 
-	} while (m_input_state_new == 0);
-	fadeInOut(prevBuffTex, timer, 25000, true);
+	} while (state_new == 0);
+	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
 

--- a/MCA/GUIMcaWarrningNoCard.h
+++ b/MCA/GUIMcaWarrningNoCard.h
@@ -7,18 +7,13 @@ class CGUIMcaWarrningNoCard :
 	public CGUIMcaPopup
 {
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	int m_slotnum;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
-	void fadeInOut(CIGUIFrameTexture *prevBuffTex, CIGUIFrameTimer *timer, u32 ms, bool out = false);
 	void drawMessage(float alpha = 1.0f);
-	CGUIMcaWarrningNoCard(void);
 public:
-	CGUIMcaWarrningNoCard(float x, float y, int slotnum);
+	CGUIMcaWarrningNoCard(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, int slotnum);
 	~CGUIMcaWarrningNoCard(void);
-	int display(CIGUIFrameRenderer *renderer, CIGUIFrameInput *input, CIGUIFrameTimer *timer, bool blur = false);
+	int display(bool blur = false);
 };
 
 #endif //_GUIMCAWARRNINGNOCARD_H_

--- a/MCA/Makefile
+++ b/MCA/Makefile
@@ -22,7 +22,7 @@ EE_OBJS =	res/resources.o ../PS2/GUIFramePS2Modules.o GUIMcaMan.o GUIMcaLang.o \
 			../PS2/GUIFrameTimerPS2.o \
 			../PS2/GUIFrameTexturePS2.o ../PS2/GUIFrameRendererPS2.o \
 			../PS2/GUIFrameInputPS2.o \
-			GUIMcaHover.o \
+			GUIMcaBaseWindow.o GUIMcaHover.o \
 			GUIMcaOperWnd.o GUIMcaPopup.o GUIMcaWarrningNoCard.o \
 			GUIMcaGetSize.o GUIMcaGetYesNo.o GUIMcaOperProgress.o \
 			GUIMcaProgressBar.o GUIMcaGetPath.o GUIMcaVkbd.o \

--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -104,12 +104,12 @@ int CPS2Application::main(int argc, char *argv[])
 		return -1;
 	}
 
-	CGUIMcaMainWnd mainWindow;
+	CGUIMcaMainWnd mainWindow(&ps2renderer, &ps2input, &ps2Timer);
 
 	ps2renderer.setAlpha(false);
 	ps2renderer.setTestAlpha(false);
 
-	mainWindow.display(&ps2renderer, &ps2input, &ps2Timer);
+	mainWindow.display();
 
 	ps2renderer.deinitRenderer();
 	ps2Timer.deinitTimer();

--- a/MCA/PS2/PS2Application.cpp
+++ b/MCA/PS2/PS2Application.cpp
@@ -221,24 +221,25 @@ std::string CPS2Application::processBootPath(const std::string& bootPath)
 bool CPS2Application::loadLanguage(const std::string& langfile)
 {
 	int fd = fioOpen(langfile.c_str(), O_BINARY | O_RDONLY);
-	if (fd > 0)
-	{
-		size_t filesize = fioLseek(fd, 0, SEEK_END);
-		fioLseek(fd, 0, SEEK_SET);
-		if (filesize > 0)
-		{
-			char *buff = new char[filesize+1];
-			fioRead(fd, buff, filesize);
-			buff[filesize] = 0;
+	if (fd <= 0)
+		return false;
 
-			CResources::mainLang.initLang(buff);
-			delete [] buff;
-			fioClose(fd);
-			return true;
-		}
+	size_t filesize = fioLseek(fd, 0, SEEK_END);
+	fioLseek(fd, 0, SEEK_SET);
+	if (filesize <= 0)
+	{
 		fioClose(fd);
+		return false;
 	}
-	return false;
+
+	char *buff = new char[filesize + 1];
+	fioRead(fd, buff, filesize);
+	buff[filesize] = 0;
+
+	CResources::mainLang.initLang(buff);
+	delete[] buff;
+	fioClose(fd);
+	return true;
 }
 
 void CPS2Application::setBootPath(const char* path)


### PR DESCRIPTION
Extracts fade in/out to a base class to prevent code duplication and move some fields into a base class.