### PR TITLE
Refactor drawing loop and getting framebuffer

### DIFF
--- a/MCA/GUIMcaAbout.cpp
+++ b/MCA/GUIMcaAbout.cpp
@@ -71,9 +71,6 @@ void CGUIMcaAbout::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaAbout::display(bool blur)
 {
-	u32 state_new = 0;
-	u32 state_all = 0;
-
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
@@ -84,24 +81,8 @@ int CGUIMcaAbout::display(bool blur)
 	{
 		prevBuffTex = m_renderer->getFrameTex();
 	}
-	u32 ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		ticks = currTick - oldTick;
-		m_input->update();
-		state_new = m_input->getNew(ticks);
-		state_all = m_input->getAll();
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while (state_new == 0);
+	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaAbout.cpp
+++ b/MCA/GUIMcaAbout.cpp
@@ -71,16 +71,8 @@ void CGUIMcaAbout::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaAbout::display(bool blur)
 {
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture *prevBuffTex = getFrameTexture(blur);
+
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);

--- a/MCA/GUIMcaBaseWindow.cpp
+++ b/MCA/GUIMcaBaseWindow.cpp
@@ -70,3 +70,14 @@ bool CGUIMcaBaseWindow::checkMessages()
 {
 	return false;
 }
+
+CIGUIFrameTexture* CGUIMcaBaseWindow::getFrameTexture(bool blur)
+{
+	CIGUIFrameTexture* prevBuffTex = m_renderer->getFrameTex(blur); //false always zero, true always one
+	if (blur)
+	{
+		prevBuffTex->blur(0);
+		prevBuffTex->blur(0);
+	}
+	return prevBuffTex;
+}

--- a/MCA/GUIMcaBaseWindow.cpp
+++ b/MCA/GUIMcaBaseWindow.cpp
@@ -29,8 +29,44 @@ CGUIMcaBaseWindow::CGUIMcaBaseWindow(CIGUIFrameRenderer* renderer, CIGUIFrameInp
 	, m_renderer(renderer)
 	, m_input(input)
 	, m_timer(timer)
+	, m_input_state_new(0)
+	, m_input_state_all(0)
+	, m_ticks(0)
+	, m_exit(false)
 {
 }
 CGUIMcaBaseWindow::~CGUIMcaBaseWindow()
 {
+}
+
+void CGUIMcaBaseWindow::drawLoop(CIGUIFrameTexture* prevBuffTex, u32 exit_buttons, float alpha)
+{
+	u32 currTick = 0, oldTick = 0;
+	currTick = oldTick = m_timer->getTicks();
+	do
+	{
+		m_ticks = currTick - oldTick;
+		m_input->update();
+		m_input_state_new = m_input->getNew(m_ticks);
+		m_input_state_all = m_input->getAll();
+
+		if (checkMessages())
+		{
+			currTick = oldTick = m_timer->getTicks();
+			if (m_exit) break;
+			else continue;
+		}
+
+		drawAll(prevBuffTex);
+		m_renderer->swapBuffers();
+
+		oldTick = currTick;
+		currTick = m_timer->getTicks();
+
+	} while ((m_input_state_new & exit_buttons) == 0);
+}
+
+bool CGUIMcaBaseWindow::checkMessages()
+{
+	return false;
 }

--- a/MCA/GUIMcaBaseWindow.h
+++ b/MCA/GUIMcaBaseWindow.h
@@ -31,6 +31,7 @@ protected:
 	* @return true if a new window was called (requires one frame advance)
 	*/
 	virtual bool checkMessages();
+	virtual CIGUIFrameTexture* getFrameTexture(bool blur = false);
 };
 
 #endif //_GUIMCABASEWINDOW_H_

--- a/MCA/GUIMcaBaseWindow.h
+++ b/MCA/GUIMcaBaseWindow.h
@@ -17,9 +17,20 @@ protected:
 	CIGUIFrameRenderer* m_renderer;
 	CIGUIFrameInput* m_input;
 	CIGUIFrameTimer* m_timer;
+	u32 m_input_state_new;
+	u32 m_input_state_all;
+	u32 m_ticks;
+	bool m_exit;
 
 	CGUIMcaBaseWindow(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x = 0, float y = 0);
 	virtual ~CGUIMcaBaseWindow();
+	virtual void drawLoop(CIGUIFrameTexture* prevBuffTex = NULL, u32 exit_buttons = 0xFFFFFFFF, float alpha = 1.0f);
+	/**
+	* @brief Check and process input messages
+	* 
+	* @return true if a new window was called (requires one frame advance)
+	*/
+	virtual bool checkMessages();
 };
 
 #endif //_GUIMCABASEWINDOW_H_

--- a/MCA/GUIMcaCardInfo.cpp
+++ b/MCA/GUIMcaCardInfo.cpp
@@ -176,16 +176,8 @@ int CGUIMcaCardInfo::displayInfo(bool blur, int oper_slot, bool psxmode)
 	m_psxmode = psxmode;
 	m_oper_slot = oper_slot;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
+
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);

--- a/MCA/GUIMcaCardInfo.cpp
+++ b/MCA/GUIMcaCardInfo.cpp
@@ -173,8 +173,6 @@ int CGUIMcaCardInfo::display(bool blur)
 }
 int CGUIMcaCardInfo::displayInfo(bool blur, int oper_slot, bool psxmode)
 {
-	u32 state_new = 0;
-	u32 state_all = 0;
 	m_psxmode = psxmode;
 	m_oper_slot = oper_slot;
 
@@ -188,24 +186,8 @@ int CGUIMcaCardInfo::displayInfo(bool blur, int oper_slot, bool psxmode)
 	{
 		prevBuffTex = m_renderer->getFrameTex();
 	}
-	u32 ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		ticks = currTick - oldTick;
-		m_input->update();
-		state_new = m_input->getNew(ticks);
-		state_all = m_input->getAll();
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while (state_new == 0);
+	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaDisplayMessage.cpp
+++ b/MCA/GUIMcaDisplayMessage.cpp
@@ -89,16 +89,8 @@ void CGUIMcaDisplayMessage::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaDisplayMessage::display(bool blur)
 {
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
+
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);

--- a/MCA/GUIMcaDisplayMessage.cpp
+++ b/MCA/GUIMcaDisplayMessage.cpp
@@ -89,9 +89,6 @@ void CGUIMcaDisplayMessage::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaDisplayMessage::display(bool blur)
 {
-	u32 state_new = 0;
-	u32 state_all = 0;
-
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
@@ -102,24 +99,8 @@ int CGUIMcaDisplayMessage::display(bool blur)
 	{
 		prevBuffTex = m_renderer->getFrameTex();
 	}
-	u32 ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		ticks = currTick - oldTick;
-		m_input->update();
-		state_new = m_input->getNew(ticks);
-		state_all = m_input->getAll();
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while (state_new == 0);
+	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaGetPath.cpp
+++ b/MCA/GUIMcaGetPath.cpp
@@ -873,16 +873,7 @@ int CGUIMcaGetPath::doGetName(std::string &ret, bool save, bool blur, const char
 	m_save = save;
 	m_caption = caption;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
 	m_prevBuffTex = prevBuffTex;
 	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);

--- a/MCA/GUIMcaGetPath.h
+++ b/MCA/GUIMcaGetPath.h
@@ -49,12 +49,8 @@ private:
 	std::string *m_curr_path;
 	std::string m_retpath;
 	std::string m_mountpath[4];
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	const char *m_defaultname;
 	bool m_save;
-	bool m_exit;
 	bool m_exit_one;
 	bool m_no_out;
 	int m_listChosen;

--- a/MCA/GUIMcaGetSize.cpp
+++ b/MCA/GUIMcaGetSize.cpp
@@ -4,9 +4,8 @@
 
 CGUIMcaGetSize::CGUIMcaGetSize(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y, int defaultmbytes)
 	: CGUIMcaPopup(renderer, input, timer, x, y)
+	, m_card_mbytes(defaultmbytes)
 {
-	m_card_mbytes = defaultmbytes;
-	m_return = false;
 }
 
 CGUIMcaGetSize::~CGUIMcaGetSize(void)
@@ -55,11 +54,9 @@ bool CGUIMcaGetSize::checkMessages()
 		if (m_card_mbytes > 128) m_card_mbytes = 1;
 	} else if (m_input_state_new & CIGUIFrameInput::enInTriangle)
 	{
-		m_return = true;
 		m_card_mbytes_ret = -1;
 	} else if (m_input_state_new & CIGUIFrameInput::enInCross)
 	{
-		m_return = true;
 		m_card_mbytes_ret = m_card_mbytes;
 	}
 	
@@ -117,30 +114,8 @@ int CGUIMcaGetSize::display(bool blur)
 	{
 		prevBuffTex = m_renderer->getFrameTex();
 	}
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ( !m_return );
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaGetSize.cpp
+++ b/MCA/GUIMcaGetSize.cpp
@@ -104,16 +104,8 @@ int CGUIMcaGetSize::display(bool blur)
 	m_input_state_new = 0;
 	m_input_state_all = 0;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
+
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);

--- a/MCA/GUIMcaGetSize.h
+++ b/MCA/GUIMcaGetSize.h
@@ -7,14 +7,10 @@ class CGUIMcaGetSize :
 	public CGUIMcaPopup
 {
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	void drawMessage(float alpha = 1.0f);
 	int m_card_mbytes;
 	int m_card_mbytes_ret;
-	bool m_return;
 	bool checkMessages();
 	u32 lzw(u32 val);
 public:

--- a/MCA/GUIMcaGetYesNo.cpp
+++ b/MCA/GUIMcaGetYesNo.cpp
@@ -89,16 +89,7 @@ int CGUIMcaGetYesNo::display(bool blur)
 	else
 		m_hover_yesno.setDest(m_x+8+20,m_y+232, true);
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
 
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);

--- a/MCA/GUIMcaGetYesNo.cpp
+++ b/MCA/GUIMcaGetYesNo.cpp
@@ -6,7 +6,6 @@ CGUIMcaGetYesNo::CGUIMcaGetYesNo(CIGUIFrameRenderer* renderer, CIGUIFrameInput* 
 	: CGUIMcaPopup(renderer, input, timer, x, y)
 	, m_result(defaultpos)
 	, m_default(defaultpos)
-	, m_return(false)
 	, m_message(message)
 	, m_hover_yesno(renderer, 222, 230, 150, 38, 0.5f, 100, 255, 255, 255, 32, 32, 32, 0.50f, 0.25f, true)
 {
@@ -18,16 +17,10 @@ CGUIMcaGetYesNo::~CGUIMcaGetYesNo(void)
 
 bool CGUIMcaGetYesNo::checkMessages()
 {
-	bool windowCalled = false;
-
 	if (m_input_state_new & CIGUIFrameInput::enInTriangle)
 	{
-		m_return = true;
 		m_result = enresNo;
 		m_hover_yesno.setDest(m_x+222+20,m_y+232, true);
-	} else if (m_input_state_new & CIGUIFrameInput::enInCross)
-	{
-		m_return = true;
 	} else if (m_input_state_new & CIGUIFrameInput::enInLeft)
 	{
 		m_result = enresYes;
@@ -38,7 +31,7 @@ bool CGUIMcaGetYesNo::checkMessages()
 		m_hover_yesno.setDest(m_x+222+20,m_y+232);
 	}
 		
-	return windowCalled;
+	return false;
 }
 
 void CGUIMcaGetYesNo::drawMessage(float alpha)
@@ -107,30 +100,8 @@ int CGUIMcaGetYesNo::display(bool blur)
 		prevBuffTex = m_renderer->getFrameTex();
 	}
 
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ( !m_return );
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaGetYesNo.h
+++ b/MCA/GUIMcaGetYesNo.h
@@ -8,14 +8,10 @@ class CGUIMcaGetYesNo :
 	public CGUIMcaPopup
 {
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	void drawMessage(float alpha = 1.0f);
 	int m_result;
 	int m_default;
-	bool m_return;
 	const char *m_message;
 	CGUIMcaHover m_hover_yesno;
 	bool checkMessages();

--- a/MCA/GUIMcaMainWnd.cpp
+++ b/MCA/GUIMcaMainWnd.cpp
@@ -358,33 +358,10 @@ int CGUIMcaMainWnd::display(bool blur)
 	m_input_state_new = 0;
 	m_input_state_all = 0;
 
-	CIGUIFrameTexture *prevBuffTex = NULL;
-	m_ticks = 0;
 	checkMessages();
-	fadeInOut(prevBuffTex,  25000, false);
-
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll();
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-	} while (true);
-	fadeInOut(prevBuffTex, 25000, true);
+	fadeInOut(NULL,  25000, false);
+	drawLoop(NULL, 0);
+	fadeInOut(NULL, 25000, true);
 
 	return 1;
 }

--- a/MCA/GUIMcaMainWnd.h
+++ b/MCA/GUIMcaMainWnd.h
@@ -13,9 +13,6 @@ class CGUIMcaMainWnd :
 {
 private:
 	int m_slot_chosen;
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 
 	//CGUITexture m_bgimage;
 	CGUITexture m_slot[2];
@@ -53,7 +50,7 @@ private:
 	{
 		u32	type;				// struct definition for ELF program section header
 		u32	offset;
-		void	*vaddr;
+		void *vaddr;
 		u32	paddr;
 		u32	filesz;
 		u32	memsz;

--- a/MCA/GUIMcaMan.h
+++ b/MCA/GUIMcaMan.h
@@ -79,14 +79,24 @@ private:
 	static bool init_done;
 	static bool init_failed;
 public:
+	struct opParams //a little trick to make all operation params the same
+	{
+		int slot;
+		bool psx;
+		bool fast;
+		int totalpages;
+		const char* path;
+		opParams(int pslot, bool ppsx, bool pfast, int ptpages, const char* ppath)
+			: slot(pslot), psx(ppsx), fast(pfast), totalpages(ptpages), path(ppath) {}
+	};
 	~CGUIMcaMan(void);
 	static void initMca();
 	static void updateMca();
 	static void getProgress();
-	static void doFormat(int slot, bool psx, bool fast, int totalpages);
-	static void doUnformat(int slot, bool psx, int totalpages);
-	static void doCreateImage(int slot, bool psx, int totalpages, const char* path);
-	static void doRestoreImage(int slot, bool psx, const char* path);
+	static void doFormat(const opParams& param);
+	static void doUnformat(const opParams& param);
+	static void doCreateImage(const opParams& param);
+	static void doRestoreImage(const opParams& param);
 };
 
 #endif //_GUIMCAMAN_H_

--- a/MCA/GUIMcaOperProgress.cpp
+++ b/MCA/GUIMcaOperProgress.cpp
@@ -7,7 +7,6 @@ CGUIMcaOperProgress::CGUIMcaOperProgress(CIGUIFrameRenderer* renderer, CIGUIFram
 	: CGUIMcaPopup(renderer, input, timer, x, y)
 	, m_result(enresFail)
 	, m_default(enresFail)
-	, m_return(false)
 	, m_locked(true)
 	, m_progressBar(renderer, x + 25, y + 224)
 {
@@ -19,8 +18,6 @@ CGUIMcaOperProgress::~CGUIMcaOperProgress(void)
 
 bool CGUIMcaOperProgress::checkMessages()
 {
-	bool windowCalled = false;
-
 	CGUIMcaMan::getProgress();
 
 	m_progressBar.setProgress(CGUIMcaMan::progressBarData.promil/1000.0f);
@@ -38,23 +35,13 @@ bool CGUIMcaOperProgress::checkMessages()
 		}
 	}
 
-	if (!m_locked)
-	{
-		if (m_input_state_new & CIGUIFrameInput::enInTriangle)
-		{
-			m_return = true;
-		} else if (m_input_state_new & CIGUIFrameInput::enInCross)
-		{
-			m_return = true;
-		}
-	}
+	if (m_locked)
+		m_input_state_new = 0; //operation in progress, do not allow exit
 
 	if (CGUIMcaMan::progressBarData.finished == 1)
-	{
 		m_locked = false;
-	}
 		
-	return windowCalled;
+	return false;
 }
 
 void CGUIMcaOperProgress::drawMessage(float alpha)
@@ -137,33 +124,9 @@ int CGUIMcaOperProgress::doFormat(int slot, bool fast, bool psx, int pagestotal,
 		prevBuffTex = m_renderer->getFrameTex();
 	}
 
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-
 	CGUIMcaMan::doFormat(slot, psx, fast, pagestotal);
-
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ( !m_return );
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
@@ -193,33 +156,9 @@ int CGUIMcaOperProgress::doUnformat(int slot, bool psx, int pagestotal, bool blu
 		prevBuffTex = m_renderer->getFrameTex();
 	}
 
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-
 	CGUIMcaMan::doUnformat(slot, psx, pagestotal);
-
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ( !m_return );
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
@@ -248,33 +187,9 @@ int CGUIMcaOperProgress::doCreateImage(int slot, bool psx, int pagestotal, const
 		prevBuffTex = m_renderer->getFrameTex();
 	}
 
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-
 	CGUIMcaMan::doCreateImage(slot, psx, pagestotal, path);
-
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ( !m_return );
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;
@@ -303,33 +218,9 @@ int CGUIMcaOperProgress::doRestoreImage(int slot, bool psx, const char *path, bo
 		prevBuffTex = m_renderer->getFrameTex();
 	}
 
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-
 	CGUIMcaMan::doRestoreImage(slot, psx, path);
-
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ( !m_return );
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaOperProgress.cpp
+++ b/MCA/GUIMcaOperProgress.cpp
@@ -1,6 +1,5 @@
 #include <string>
 #include "GUIMcaOperProgress.h"
-#include "GUIMcaMan.h"
 #include "res/resources.h"
 
 CGUIMcaOperProgress::CGUIMcaOperProgress(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y)
@@ -14,6 +13,22 @@ CGUIMcaOperProgress::CGUIMcaOperProgress(CIGUIFrameRenderer* renderer, CIGUIFram
 
 CGUIMcaOperProgress::~CGUIMcaOperProgress(void)
 {
+}
+
+int CGUIMcaOperProgress::doOperation(const CGUIMcaMan::opParams& params, void(*operation)(const CGUIMcaMan::opParams&), float blur)
+{
+	resetProgress();
+
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
+
+	fadeInOut(prevBuffTex, 25000, false);
+	operation(params);
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
+	fadeInOut(prevBuffTex, 25000, true);
+
+	delete prevBuffTex;
+
+	return m_result;
 }
 
 bool CGUIMcaOperProgress::checkMessages()
@@ -102,7 +117,7 @@ int CGUIMcaOperProgress::display(bool blur)
 	return 0;
 }
 
-int CGUIMcaOperProgress::doFormat(int slot, bool fast, bool psx, int pagestotal, bool blur)
+void CGUIMcaOperProgress::resetProgress()
 {
 	m_result = m_default;
 	m_input_state_new = 0;
@@ -111,83 +126,24 @@ int CGUIMcaOperProgress::doFormat(int slot, bool fast, bool psx, int pagestotal,
 	CGUIMcaMan::progressBarData.error = 0;
 	CGUIMcaMan::progressBarData.promil = 0;
 	CGUIMcaMan::progressBarData.finished = 0;
+}
 
-
-	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
-
-	fadeInOut(prevBuffTex, 25000, false);
-	CGUIMcaMan::doFormat(slot, psx, fast, pagestotal);
-	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
-	fadeInOut(prevBuffTex, 25000, true);
-
-	delete prevBuffTex;
-
-	return m_result;
+int CGUIMcaOperProgress::doFormat(int slot, bool fast, bool psx, int pagestotal, bool blur)
+{
+	return doOperation(CGUIMcaMan::opParams(slot, psx, fast, pagestotal, ""), CGUIMcaMan::doFormat, blur);
 }
 
 int CGUIMcaOperProgress::doUnformat(int slot, bool psx, int pagestotal, bool blur)
 {
-	m_result = m_default;
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-
-	m_progressBar.setProgress(0);
-	CGUIMcaMan::progressBarData.error = 0;
-	CGUIMcaMan::progressBarData.promil = 0;
-	CGUIMcaMan::progressBarData.finished = 0;
-
-	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
-
-	fadeInOut(prevBuffTex, 25000, false);
-	CGUIMcaMan::doUnformat(slot, psx, pagestotal);
-	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
-	fadeInOut(prevBuffTex, 25000, true);
-
-	delete prevBuffTex;
-
-	return m_result;
+	return doOperation(CGUIMcaMan::opParams(slot, psx, false, pagestotal, ""), CGUIMcaMan::doUnformat, blur);
 }
 
 int CGUIMcaOperProgress::doCreateImage(int slot, bool psx, int pagestotal, const char *path, bool blur)
 {
-	m_result = m_default;
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-	m_progressBar.setProgress(0);
-	CGUIMcaMan::progressBarData.error = 0;
-	CGUIMcaMan::progressBarData.promil = 0;
-	CGUIMcaMan::progressBarData.finished = 0;
-
-	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
-
-	fadeInOut(prevBuffTex, 25000, false);
-	CGUIMcaMan::doCreateImage(slot, psx, pagestotal, path);
-	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
-	fadeInOut(prevBuffTex, 25000, true);
-
-	delete prevBuffTex;
-
-	return m_result;
+	return doOperation(CGUIMcaMan::opParams(slot, psx, false, pagestotal, path), CGUIMcaMan::doCreateImage, blur);
 }
 
 int CGUIMcaOperProgress::doRestoreImage(int slot, bool psx, const char *path, bool blur)
 {
-	m_result = m_default;
-	m_input_state_new = 0;
-	m_input_state_all = 0;
-	m_progressBar.setProgress(0);
-	CGUIMcaMan::progressBarData.error = 0;
-	CGUIMcaMan::progressBarData.promil = 0;
-	CGUIMcaMan::progressBarData.finished = 0;
-
-	CIGUIFrameTexture *prevBuffTex = getFrameTexture(blur);
-
-	fadeInOut(prevBuffTex, 25000, false);
-	CGUIMcaMan::doRestoreImage(slot, psx, path);
-	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle | CIGUIFrameInput::enInCross);
-	fadeInOut(prevBuffTex, 25000, true);
-
-	delete prevBuffTex;
-
-	return m_result;
+	return doOperation(CGUIMcaMan::opParams(slot, psx, false, 0, path), CGUIMcaMan::doRestoreImage, blur);
 }

--- a/MCA/GUIMcaOperProgress.cpp
+++ b/MCA/GUIMcaOperProgress.cpp
@@ -113,16 +113,7 @@ int CGUIMcaOperProgress::doFormat(int slot, bool fast, bool psx, int pagestotal,
 	CGUIMcaMan::progressBarData.finished = 0;
 
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
 
 	fadeInOut(prevBuffTex, 25000, false);
 	CGUIMcaMan::doFormat(slot, psx, fast, pagestotal);
@@ -145,16 +136,7 @@ int CGUIMcaOperProgress::doUnformat(int slot, bool psx, int pagestotal, bool blu
 	CGUIMcaMan::progressBarData.promil = 0;
 	CGUIMcaMan::progressBarData.finished = 0;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
 
 	fadeInOut(prevBuffTex, 25000, false);
 	CGUIMcaMan::doUnformat(slot, psx, pagestotal);
@@ -176,16 +158,7 @@ int CGUIMcaOperProgress::doCreateImage(int slot, bool psx, int pagestotal, const
 	CGUIMcaMan::progressBarData.promil = 0;
 	CGUIMcaMan::progressBarData.finished = 0;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture(blur);
 
 	fadeInOut(prevBuffTex, 25000, false);
 	CGUIMcaMan::doCreateImage(slot, psx, pagestotal, path);
@@ -207,16 +180,7 @@ int CGUIMcaOperProgress::doRestoreImage(int slot, bool psx, const char *path, bo
 	CGUIMcaMan::progressBarData.promil = 0;
 	CGUIMcaMan::progressBarData.finished = 0;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture *prevBuffTex = getFrameTexture(blur);
 
 	fadeInOut(prevBuffTex, 25000, false);
 	CGUIMcaMan::doRestoreImage(slot, psx, path);

--- a/MCA/GUIMcaOperProgress.h
+++ b/MCA/GUIMcaOperProgress.h
@@ -8,14 +8,10 @@ class CGUIMcaOperProgress :
 	public CGUIMcaPopup
 {
 private:
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	void drawAll(CIGUIFrameTexture *prevBuffTex = NULL, float alpha = 1.0f);
 	void drawMessage(float alpha = 1.0f);
 	int m_result;
 	int m_default;
-	bool m_return;
 	bool m_locked;
 	CGUIMcaProgressBar m_progressBar;
 	bool checkMessages();

--- a/MCA/GUIMcaOperProgress.h
+++ b/MCA/GUIMcaOperProgress.h
@@ -3,6 +3,7 @@
 
 #include "GUIMcaPopup.h"
 #include "GUIMcaProgressBar.h"
+#include "GUIMcaMan.h"
 
 class CGUIMcaOperProgress :
 	public CGUIMcaPopup
@@ -16,6 +17,7 @@ private:
 	CGUIMcaProgressBar m_progressBar;
 	bool checkMessages();
 	int display(bool blur = false);
+	void resetProgress();
 public:
 	enum enResult
 	{
@@ -24,6 +26,7 @@ public:
 	};
 	CGUIMcaOperProgress(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y);
 	~CGUIMcaOperProgress(void);
+    int doOperation(const CGUIMcaMan::opParams& params, void (*operation)(const CGUIMcaMan::opParams&), float blur);
 	int doFormat(int slot, bool fast, bool psx, int pagestotal, bool blur = false);
 	int doUnformat(int slot, bool psx, int pagestotal, bool blur = false);
 	int doCreateImage(int slot, bool psx, int pagestotal, const char* path, bool blur = false);

--- a/MCA/GUIMcaOperWnd.cpp
+++ b/MCA/GUIMcaOperWnd.cpp
@@ -34,7 +34,7 @@ bool CGUIMcaOperWnd::checkMessages()
 	{
 		CGUIMcaWarrningNoCard myWarn(m_renderer, m_input, m_timer, 110, 106, m_oper_slot);
 		myWarn.display(true);
-		m_exit_now = true;
+		m_exit = true;
 		windowCalled = true;
 		return windowCalled;
 	}
@@ -118,7 +118,7 @@ bool CGUIMcaOperWnd::checkMessages()
 							}
 							CGUIMcaOperProgress formatProgress(m_renderer, m_input, m_timer, 110, 106);
 							formatProgress.doFormat(m_oper_slot, m_menu_item_format == 0 ? true : false, m_psx_mode, totalpages);
-							m_exit_now = true;
+							m_exit = true;
 						}
 					}
 				}
@@ -160,7 +160,7 @@ bool CGUIMcaOperWnd::checkMessages()
 							}
 							CGUIMcaOperProgress unformatProgress(m_renderer, m_input, m_timer, 110, 106);
 							unformatProgress.doUnformat(m_oper_slot, m_psx_mode, totalpages);
-							m_exit_now = true;
+							m_exit = true;
 						}
 					}
 				}
@@ -243,7 +243,7 @@ bool CGUIMcaOperWnd::checkMessages()
 						CGUIMcaOperProgress createProgress(m_renderer, m_input, m_timer, 110, 106);
 						createProgress.doCreateImage(m_oper_slot, m_psx_mode, totalpages, result.c_str(), false);
 						if (result.substr(0, 5) == "hdd0:") fileXioUmount("pfs0:");
-						m_exit_now = true;
+						m_exit = true;
 					}
 				}
 				windowCalled = true;
@@ -284,7 +284,7 @@ bool CGUIMcaOperWnd::checkMessages()
 						CGUIMcaOperProgress restoreProgress(m_renderer, m_input, m_timer, 110, 106);
 						restoreProgress.doRestoreImage(m_oper_slot, m_psx_mode, result.c_str(), false);
 						if (result.substr(0, 5) == "hdd0:") fileXioUmount("pfs0:");
-						m_exit_now = true;
+						m_exit = true;
 					}
 				}
 				windowCalled = true;
@@ -318,7 +318,6 @@ CGUIMcaOperWnd::CGUIMcaOperWnd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* in
 	, m_menu_item(0)
 	, m_menu_item_format(0)
 	, m_psx_mode(false)
-	, m_exit_now(false)
 	, m_hover_menu(renderer, 70, 248, 450, 24, 0.1f, 600, 255, 255, 255, 32, 32, 32, 0.50f, 0.25f, true)
 {
 	CResources::m_bgimage.loadTextureBuffer(CResources::bgimg_tm2, CResources::size_bgimg_tm2, true);
@@ -433,7 +432,7 @@ void CGUIMcaOperWnd::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaOperWnd::display(bool blur)
 {
-	m_exit_now = false;
+	m_exit = false;
 	m_input_state_new = 0;
 	m_input_state_all = 0;
 
@@ -442,33 +441,9 @@ int CGUIMcaOperWnd::display(bool blur)
 	m_hover_menu.setDest(70, 248 +26*m_menu_item, true);
 
 	CIGUIFrameTexture *prevBuffTex = m_renderer->getFrameTex();
-	m_ticks = 0;
 	checkMessages();
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		if (m_exit_now) break;
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-
-		drawAll();
-
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ((m_input_state_new & CIGUIFrameInput::enInTriangle) == 0);
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;

--- a/MCA/GUIMcaOperWnd.cpp
+++ b/MCA/GUIMcaOperWnd.cpp
@@ -440,7 +440,7 @@ int CGUIMcaOperWnd::display(bool blur)
 	m_menu_item_format = 0;
 	m_hover_menu.setDest(70, 248 +26*m_menu_item, true);
 
-	CIGUIFrameTexture *prevBuffTex = m_renderer->getFrameTex();
+	CIGUIFrameTexture* prevBuffTex = getFrameTexture();
 	checkMessages();
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle);

--- a/MCA/GUIMcaOperWnd.h
+++ b/MCA/GUIMcaOperWnd.h
@@ -14,11 +14,7 @@ private:
 	int m_menu_item;
 	int m_menu_item_format;
 	int m_oper_slot;
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	bool m_psx_mode;
-	bool m_exit_now;
 
 	CGUITexture m_mca_logo;
 	CGUITexture m_mc_bg;

--- a/MCA/GUIMcaVkbd.cpp
+++ b/MCA/GUIMcaVkbd.cpp
@@ -255,22 +255,8 @@ int CGUIMcaVkbd::getEntry(const char *defname, std::string &ret, u32 max_chars, 
 	m_over_num = -1;
 	m_filename = filename_mode;
 
-	CIGUIFrameTexture *prevBuffTex;
-	if (prevtex != NULL)
-	{
-		prevBuffTex = prevtex;
-	} else
-	{
-		if (blur)
-		{
-			prevBuffTex = m_renderer->getFrameTex(1);
-			prevBuffTex->blur(0);
-			prevBuffTex->blur(0);
-		} else
-		{
-			prevBuffTex = m_renderer->getFrameTex();
-		}
-	}
+	CIGUIFrameTexture *prevBuffTex = (prevtex != NULL) ? prevtex : getFrameTexture(blur);
+
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle);
 	fadeInOut(prevBuffTex, 25000, true);

--- a/MCA/GUIMcaVkbd.cpp
+++ b/MCA/GUIMcaVkbd.cpp
@@ -13,7 +13,6 @@ CGUIMcaVkbd::CGUIMcaVkbd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, C
 	, m_caret_ticks(0)
 	, m_curx(0)
 	, m_cury(0)
-	, m_exit_now(false)
 	, m_caps(false)
 	, m_shift(false)
 	, m_tmp_shift(false)
@@ -135,6 +134,8 @@ bool CGUIMcaVkbd::checkMessages()
 {
 	bool windowCalled = false;
 
+	updateKbPosition();
+
 	if (m_input_state_new & CIGUIFrameInput::enInL1) m_caps = !m_caps;
 	m_shift = m_input_state_all & CIGUIFrameInput::enInR1;
 	if (m_input_state_new & CIGUIFrameInput::enInR1) m_tmp_shift = false;
@@ -183,11 +184,11 @@ bool CGUIMcaVkbd::checkMessages()
 					if (m_text.size() > 0) m_text.resize(m_text.size()-1);
 					break;
 				case enfkEnter:
-					m_exit_now = true;
+					m_exit = true;
 					windowCalled = true;
 					if (m_filename && m_text.find_first_of("\\/:*?\"<>|") != std::string::npos)
 					{
-						m_exit_now = false;
+						m_exit = false;
 						CGUIMcaDisplayMessage myMessage(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_VKBD_WARN_WRONG_NAME"), NULL, CGUIMcaDisplayMessage::enIcFail, CIGUIFrameFont<CGUITexture>::etxAlignCenter);
 						myMessage.display(true);
 					} else if (m_filename)
@@ -206,11 +207,11 @@ bool CGUIMcaVkbd::checkMessages()
 		if (m_text.size() > 0) m_text.resize(m_text.size()-1);
 	} else if (m_input_state_new & CIGUIFrameInput::enInStart)
 	{
-		m_exit_now = true;
+		m_exit = true;
 		windowCalled = true;
 		if (m_filename && m_text.find_first_of("\\/:*?\"<>|") != std::string::npos)
 		{
-			m_exit_now = false;
+			m_exit = false;
 			CGUIMcaDisplayMessage myMessage(m_renderer, m_input, m_timer, 110, 106, CResources::mainLang.getText("LNG_VKBD_WARN_WRONG_NAME"), NULL, CGUIMcaDisplayMessage::enIcFail, CIGUIFrameFont<CGUITexture>::etxAlignCenter);
 			myMessage.display(true);
 		} else if (m_filename)
@@ -223,6 +224,23 @@ bool CGUIMcaVkbd::checkMessages()
 	return windowCalled;
 }
 
+void CGUIMcaVkbd::updateKbPosition()
+{
+	float cxadd, cyadd;
+	m_input->getAdditive(cxadd, cyadd);
+	if (m_input_state_all & CIGUIFrameInput::enInLeft) cxadd = -1.0f;
+	else if (m_input_state_all & CIGUIFrameInput::enInRight) cxadd = 1.0f;
+	if (m_input_state_all & CIGUIFrameInput::enInUp) cyadd = -1.0f;
+	else if (m_input_state_all & CIGUIFrameInput::enInDown) cyadd = 1.0f;
+
+	m_curx += (cxadd * ((float)m_ticks / 450.0f));
+	m_cury += (cyadd * ((float)m_ticks / 450.0f));
+	if (m_curx + m_x < 0) m_curx = -m_x;
+	else if (m_curx + m_x > 640) m_curx = 640 - m_x;
+	if (m_cury + m_y < 0) m_cury = -m_y;
+	else if (m_cury + m_y > 512) m_cury = 512 - m_y;
+}
+
 int CGUIMcaVkbd::getEntry(const char *defname, std::string &ret, u32 max_chars, CIGUIFrameTexture *prevtex, bool blur, bool filename_mode)
 {
 	m_input_state_new = 0;
@@ -233,7 +251,7 @@ int CGUIMcaVkbd::getEntry(const char *defname, std::string &ret, u32 max_chars, 
 	m_max_chars = max_chars;
 	m_display_caret = false;
 	m_caret_ticks = 0;
-	m_exit_now = false;
+	m_exit = false;
 	m_over_num = -1;
 	m_filename = filename_mode;
 
@@ -253,49 +271,13 @@ int CGUIMcaVkbd::getEntry(const char *defname, std::string &ret, u32 max_chars, 
 			prevBuffTex = m_renderer->getFrameTex();
 		}
 	}
-	m_ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		if (m_exit_now) break;
-		m_ticks = currTick - oldTick;
-		m_input->update();
-		m_input_state_new = m_input->getNew(m_ticks);
-		m_input_state_all = m_input->getAll();
-
-		float cxadd, cyadd;
-		m_input->getAdditive(cxadd, cyadd);
-		if (m_input_state_all & CIGUIFrameInput::enInLeft) cxadd = -1.0f;
-		else if (m_input_state_all & CIGUIFrameInput::enInRight) cxadd = 1.0f;
-		if (m_input_state_all & CIGUIFrameInput::enInUp) cyadd = -1.0f;
-		else if (m_input_state_all & CIGUIFrameInput::enInDown) cyadd = 1.0f;
-
-		m_curx += (cxadd*((float)m_ticks/450.0f));
-		m_cury += (cyadd*((float)m_ticks/450.0f));
-		if (m_curx + m_x < 0) m_curx = -m_x;
-		else if (m_curx + m_x > 640) m_curx = 640-m_x;
-		if (m_cury + m_y < 0) m_cury = -m_y;
-		else if (m_cury + m_y > 512) m_cury = 512-m_y;
-
-		if (checkMessages())
-		{
-			currTick = oldTick = m_timer->getTicks();
-			continue;
-		}
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while ((m_input_state_new & CIGUIFrameInput::enInTriangle) == 0);
+	drawLoop(prevBuffTex, CIGUIFrameInput::enInTriangle);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	if (prevtex == NULL) delete prevBuffTex;
 
-	if (m_exit_now)
+	if (m_exit)
 	{
 		ret = m_text;
 		return 1;

--- a/MCA/GUIMcaVkbd.h
+++ b/MCA/GUIMcaVkbd.h
@@ -52,13 +52,9 @@ private:
 	u32 m_caret_ticks;
 	float m_curx;
 	float m_cury;
-	bool m_exit_now;
 	bool m_caps;
 	bool m_shift;
 	bool m_tmp_shift;
-	u32 m_input_state_new;
-	u32 m_input_state_all;
-	u32 m_ticks;
 	std::string m_text;
 	bool m_filename;
 	void drawWindow(float alpha = 1.0f);
@@ -67,6 +63,7 @@ private:
 	void drawText(float alpha = 1.0f);
 	void drawKeys(float alpha = 1.0f);
 	bool checkMessages();
+	void updateKbPosition();
 public:
 	CGUIMcaVkbd(CIGUIFrameRenderer* renderer, CIGUIFrameInput* input, CIGUIFrameTimer* timer, float x, float y);
 	~CGUIMcaVkbd(void);

--- a/MCA/GUIMcaWarrningNoCard.cpp
+++ b/MCA/GUIMcaWarrningNoCard.cpp
@@ -41,16 +41,8 @@ void CGUIMcaWarrningNoCard::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaWarrningNoCard::display(bool blur)
 {
-	CIGUIFrameTexture *prevBuffTex;
-	if (blur)
-	{
-		prevBuffTex = m_renderer->getFrameTex(1);
-		prevBuffTex->blur(0);
-		prevBuffTex->blur(0);
-	} else
-	{
-		prevBuffTex = m_renderer->getFrameTex();
-	}
+	CIGUIFrameTexture *prevBuffTex = getFrameTexture(blur);
+
 	fadeInOut(prevBuffTex, 25000, false);
 	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);

--- a/MCA/GUIMcaWarrningNoCard.cpp
+++ b/MCA/GUIMcaWarrningNoCard.cpp
@@ -41,9 +41,6 @@ void CGUIMcaWarrningNoCard::drawAll(CIGUIFrameTexture *prevBuffTex, float alpha)
 
 int CGUIMcaWarrningNoCard::display(bool blur)
 {
-	u32 state_new = 0;
-	u32 state_all = 0;
-
 	CIGUIFrameTexture *prevBuffTex;
 	if (blur)
 	{
@@ -54,24 +51,8 @@ int CGUIMcaWarrningNoCard::display(bool blur)
 	{
 		prevBuffTex = m_renderer->getFrameTex();
 	}
-	u32 ticks = 0;
 	fadeInOut(prevBuffTex, 25000, false);
-	u32 currTick = 0, oldTick = 0;
-	currTick = oldTick = m_timer->getTicks();
-	do
-	{
-		ticks = currTick - oldTick;
-		m_input->update();
-		state_new = m_input->getNew(ticks);
-		state_all = m_input->getAll();
-
-		drawAll(prevBuffTex);
-		m_renderer->swapBuffers();
-
-		oldTick = currTick;
-		currTick = m_timer->getTicks();
-
-	} while (state_new == 0);
+	drawLoop(prevBuffTex);
 	fadeInOut(prevBuffTex, 25000, true);
 
 	delete prevBuffTex;


### PR DESCRIPTION
Extracts drawing loop and getting frambuffer texture to a base class. This significantly reduces code duplication and should improve maintainability. I left get path untouched in this regard, because it's a whole another beast to tame.

Along that moves some members into a base class.

Also changes operation arguments to a struct, to allow further reducing of duplicated code (c++98 constraints).